### PR TITLE
Added collections and lazy manifests

### DIFF
--- a/src/Model/Canvas.php
+++ b/src/Model/Canvas.php
@@ -17,7 +17,6 @@ class Canvas
 
     public function __construct(string $id, string $label, string $thumbnail = null, int $height, int $width, array $images)
     {
-
         $this->label = $label;
         $this->height = $height;
         $this->width = $width;
@@ -40,6 +39,7 @@ class Canvas
     public function getRegion(Region $region, $num = 0)
     {
         $image = $this->getImage($num);
+
         return $image->getImageService()->getRegion($region);
     }
 
@@ -48,6 +48,7 @@ class Canvas
         if ($this->thumbnail) {
             return $this->thumbnail;
         }
+
         return $this->getImage()->getThumbnail();
     }
 
@@ -62,12 +63,13 @@ class Canvas
         if (isset($thumbnail['@id'])) {
             return $thumbnail['@id'];
         }
+
         return null;
     }
 
     public static function fromArray($canvas)
     {
-        $images = array_map(function($image) {
+        $images = array_map(function ($image) {
             return Image::fromArray($image);
         }, $canvas['images']);
 

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace IIIF\Model;
+
+class Collection
+{
+    private $id;
+    private $manifests;
+    private $label;
+    private $description;
+    private $attribution;
+    private $metadata;
+
+    const TYPE = 'sc:collection';
+
+    public static function isCollection(array $data)
+    {
+        return strtolower($data['@type']) === self::TYPE;
+    }
+
+    public function __construct(
+        string $id,
+        string $label = null,
+        string $description = null,
+        string $attribution = null,
+        array $manifests = [],
+        array $metadata = null
+    ) {
+        $this->id = $id;
+        $this->label = $label;
+        $this->description = $description;
+        $this->attribution = $attribution;
+        $this->manifests = $manifests;
+        $this->metadata = $metadata;
+    }
+
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    public static function fromJson(string $json)
+    {
+        return static::fromArray(json_decode($json, true));
+    }
+
+    private static function getLabelFromData($data)
+    {
+        if (is_string($data)) {
+            return $data;
+        }
+        if (isset($data['@value'])) {
+            return $data['@value'];
+        }
+        if (isset($data[0]['@value'])) {
+            return $data[0]['@value'];
+        }
+
+        return null;
+    }
+
+    private static function getManifestsFromData($data)
+    {
+        if (isset($data['members'])) {
+            return $data['members'];
+        }
+        if (isset($data['manifests'])) {
+            return $data['manifests'];
+        }
+
+        return [];
+    }
+
+    public function getManifests()
+    {
+        return $this->manifests;
+    }
+
+    public static function fromArray(array $data)
+    {
+        return new static(
+            $data['@id'],
+            static::getLabelFromData($data['label'] ?? []),
+            $data['description'] ?? null,
+            $data['attribution'] ?? null,
+            array_map(function ($manifest) {
+                return LazyManifest::fromArray($manifest);
+            }, static::getManifestsFromData($data))
+        );
+    }
+
+    public function setManifestLoader(callable $loader)
+    {
+        $manifests = $this->getManifests();
+        foreach ($manifests as $manifest) {
+            /* @var LazyManifest $manifest */
+            $manifest->setLoader($loader);
+        }
+    }
+}

--- a/src/Model/Image.php
+++ b/src/Model/Image.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace IIIF\Model;
-
 
 class Image
 {
@@ -16,8 +14,7 @@ class Image
         string $motivation,
         string $on,
         ImageResource $imageService
-    )
-    {
+    ) {
         $this->resource = $imageService;
         $this->id = $id;
         $this->motivation = $motivation;

--- a/src/Model/ImageResource.php
+++ b/src/Model/ImageResource.php
@@ -18,8 +18,7 @@ class ImageResource
         int $height,
         int $width,
         ImageService $service = null
-    )
-    {
+    ) {
         $this->service = $service;
         $this->id = $id;
         $this->type = $type;

--- a/src/Model/ImageService.php
+++ b/src/Model/ImageService.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace IIIF\Model;
-
 
 class ImageService
 {
@@ -17,8 +15,7 @@ class ImageService
         int $height,
         int $width,
         array $tiles = null
-    )
-    {
+    ) {
         $this->tiles = $tiles ? $tiles : [];
         $this->id = $id;
         $this->height = $height;
@@ -51,18 +48,21 @@ class ImageService
                 $largest = $tile->getLargestDimension();
             }
         }
+
         return $largest === 0 ? 256 : $largest;
     }
 
     public function getThumbnail()
     {
         $largestTile = $this->getLargestTile();
-        return $this->id . '/full/' . $largestTile .',' . $largestTile . '/0/default.jpg';
+
+        return $this->id.'/full/'.$largestTile.','.$largestTile.'/0/default.jpg';
     }
 
     public function getRegion(Region $region)
     {
         $largestTile = $this->getLargestTile();
-        return $this->id . '/' . $region->getX() .',' . $region->getY() . ',' . $region->getWidth() . ',' . $region->getHeight(). '/' . $largestTile .',' . $largestTile . '/0/default.jpg';
+
+        return $this->id.'/'.$region->getX().','.$region->getY().','.$region->getWidth().','.$region->getHeight().'/'.$largestTile.','.$largestTile.'/0/default.jpg';
     }
 }

--- a/src/Model/LazyManifest.php
+++ b/src/Model/LazyManifest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace IIIF\Model;
+
+class LazyManifest extends Manifest
+{
+    private $isLoaded = false;
+    private $loader;
+
+    public function __construct($id, $label = null, array $sequences = null)
+    {
+        $this->loader = function ($url) {
+            return json_decode(file_get_contents($url), true);
+        };
+        parent::__construct($id, $label, $sequences);
+    }
+
+    public function setLoader(callable $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    public static function fromArray(array $data): Manifest
+    {
+        return new static(
+            $data['@id'],
+            $data['label'] ?? null,
+            array_map(function ($sequence) {
+                return Sequence::fromArray($sequence);
+            }, $data['sequences'] ?? [])
+        );
+    }
+
+    private function load()
+    {
+        if ($this->isLoaded) {
+            return null;
+        }
+        $loader = $this->loader;
+        $data = $loader($this->id);
+        $this->label = $data['label'] ?? null;
+        $this->sequences = array_map(function ($sequence) {
+            return Sequence::fromArray($sequence);
+        }, $data['sequences'] ?? []);
+        $this->isLoaded = true;
+    }
+
+    public function getLabel(): string
+    {
+        $this->load();
+
+        return parent::getLabel();
+    }
+
+    public function getDefaultSequence(): Sequence
+    {
+        $this->load();
+
+        return parent::getDefaultSequence();
+    }
+
+    /** @return Sequence */
+    public function getSequence($num)
+    {
+        $this->load();
+
+        return parent::getSequence($num);
+    }
+}

--- a/src/Model/Region.php
+++ b/src/Model/Region.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace IIIF\Model;
-
 
 class Region
 {
@@ -62,6 +60,7 @@ class Region
     {
         $matches = [];
         preg_match(self::W3C_REGEX, $url, $matches);
+
         return new static(
             $matches[1] ? $matches[1] : 'pixel',
             $matches[2] ?? 0,
@@ -81,5 +80,4 @@ class Region
             $w
         );
     }
-
 }

--- a/src/Model/Sequence.php
+++ b/src/Model/Sequence.php
@@ -13,8 +13,9 @@ class Sequence
         $this->label = $label;
     }
 
-    public static function fromArray(array $sequence) {
-        $canvases = array_map(function($canvas) {
+    public static function fromArray(array $sequence)
+    {
+        $canvases = array_map(function ($canvas) {
             return Canvas::fromArray($canvas);
         }, $sequence['canvases']);
 
@@ -41,7 +42,7 @@ class Sequence
                 return $canvas;
             }
         }
+
         return null;
     }
-
 }

--- a/src/Model/Tile.php
+++ b/src/Model/Tile.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace IIIF\Model;
-
 
 class Tile
 {

--- a/tests/fixtures/collection-manifest-field.json
+++ b/tests/fixtures/collection-manifest-field.json
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "http://dams.llgc.org.uk/iiif/collection/gle.json",
+  "@type": "sc:Collection",
+  "label": [
+    {
+      "@value": "[Trawsfynydd Carnival, Images of O'Brien and John Douglas]",
+      "@language": "en"
+    },
+    {
+      "@value": "",
+      "@language": "cy-GB"
+    }
+  ],
+  "description": "Images of Trawsfynydd Carnival, Images of O'Brien and John Douglas.",
+  "attribution": "Llyfrgell Genedlaethol Cymru – The National Library of Wales",
+  "metadata": [
+    {
+      "label": [
+        {
+          "@value": "Title",
+          "@language": "en"
+        },
+        {
+          "@value": "Teitl",
+          "@language": "cy-GB"
+        }
+      ],
+      "value": [
+        {
+          "@value": "[Trawsfynydd Carnival, Images of O'Brien and John Douglas]",
+          "@language": "en"
+        },
+        {
+          "@value": "",
+          "@language": "cy-GB"
+        }
+      ]
+    },
+    {
+      "label": [
+        {
+          "@value": "Author",
+          "@language": "en"
+        },
+        {
+          "@value": "Awdur",
+          "@language": "cy-GB"
+        }
+      ],
+      "value": "Evans, Gwilym Livingstone photographer."
+    },
+    {
+      "label": [
+        {
+          "@value": "Period",
+          "@language": "en"
+        },
+        {
+          "@value": "Cyfnod",
+          "@language": "cy-GB"
+        }
+      ],
+      "value": "1968."
+    },
+    {
+      "label": [
+        {
+          "@value": "Physical description",
+          "@language": "en"
+        },
+        {
+          "@value": "Disgrifiad ffisegol",
+          "@language": "cy-GB"
+        }
+      ],
+      "value": "24 slides : black and white ; 6 x 6 cm. or smaller."
+    },
+    {
+      "label": [
+        {
+          "@value": "Repository",
+          "@language": "en"
+        },
+        {
+          "@value": "Ystorfa",
+          "@language": "cy-GB"
+        }
+      ],
+      "value": [
+        {
+          "@value": "This content has been digitised by The National Library of Wales",
+          "@language": "en"
+        },
+        {
+          "@value": "Digidwyd y cynnwys hwn gan Lyfrgell Genedlaethol Cymru",
+          "@language": "cy-GB"
+        }
+      ]
+    }
+  ],
+  "manifests": [
+    {
+      "@id": "http://dams.llgc.org.uk/iiif/2.0/4693064/manifest.json",
+      "@type": "sc:Manifest",
+      "label": "Contact Sheet 1 Box 1",
+      "description": ""
+    },
+    {
+      "@id": "http://dams.llgc.org.uk/iiif/2.0/4693089/manifest.json",
+      "@type": "sc:Manifest",
+      "label": "Contact Sheet 2 Box 1",
+      "description": ""
+    },
+    {
+      "@id": "http://dams.llgc.org.uk/iiif/2.0/4693105/manifest.json",
+      "@type": "sc:Manifest",
+      "label": "Contact Sheet 3 Box 1",
+      "description": ""
+    },
+    {
+      "@id": "http://dams.llgc.org.uk/iiif/2.0/4693116/manifest.json",
+      "@type": "sc:Manifest",
+      "label": "Contact Sheet 4 Box 1",
+      "description": ""
+    },
+    {
+      "@id": "http://dams.llgc.org.uk/iiif/2.0/4654878/manifest.json",
+      "@type": "sc:Manifest",
+      "label": "Contact Sheet 5 Box 1",
+      "description": "Wm. Carey Jones, Isfryn, 4, Gwaenydd Terr. Rhiw-S Snar Traws. Part Marian Bryfdir Wedding."
+    }
+  ]
+}

--- a/tests/fixtures/collection-member-field.json
+++ b/tests/fixtures/collection-member-field.json
@@ -1,0 +1,67 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://presley.dlcs-ida.org/iiif/idatest01/collection/_roll_M-1011_145_",
+  "@type": "sc:Collection",
+  "members": [
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-31-33/manifest",
+      "@type": "sc:Manifest",
+      "label": "Standing Rock Demo 1"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-4-28/manifest",
+      "@type": "sc:Manifest",
+      "label": "Finding Aid, M1011-145"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-30-47/manifest",
+      "@type": "sc:Manifest",
+      "label": "1932 Standing Rock, Narrative Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-48-134/manifest",
+      "@type": "sc:Manifest",
+      "label": "1932 Standing Rock, Statistical Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-135-152/manifest",
+      "@type": "sc:Manifest",
+      "label": "1933, Standing Rock, Narrative Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-153-209/manifest",
+      "@type": "sc:Manifest",
+      "label": "1933, Standing Rock, Statistical Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-210-235/manifest",
+      "@type": "sc:Manifest",
+      "label": "1934, Standing Rock, Narrative Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-236-298/manifest",
+      "@type": "sc:Manifest",
+      "label": "1934, Standing Rock, Statistical Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-299-343/manifest",
+      "@type": "sc:Manifest",
+      "label": "1934, Standing Rock, Statistical Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-344-447/manifest",
+      "@type": "sc:Manifest",
+      "label": "1935, Standing Rock, Statistical Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-449-453/manifest",
+      "@type": "sc:Manifest",
+      "label": "1930, Tacoma Hospital - Narrative Report"
+    },
+    {
+      "@id": "https://presley.dlcs-ida.org/iiif/idatest01/_roll_M-1011_145_cvs-454-467/manifest",
+      "@type": "sc:Manifest",
+      "label": "1930 Tacoma Hospital, Statistical Report"
+    }
+  ]
+}

--- a/tests/model/CollectionTest.php
+++ b/tests/model/CollectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace IIIF\tests\model;
+
+use IIIF\Model\Collection;
+use IIIF\Model\LazyManifest;
+use PHPUnit\Framework\TestCase;
+
+class CollectionTest extends TestCase
+{
+
+    public function test_can_load_collection_with_manifest_field()
+    {
+        $collectionData = file_get_contents(__DIR__ . '/../fixtures/collection-manifest-field.json');
+        $collection = Collection::fromJson($collectionData);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals(5, sizeof($collection->getManifests()));
+        $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
+
+        $this->assertEquals('[Trawsfynydd Carnival, Images of O\'Brien and John Douglas]', $collection->getLabel());
+    }
+
+    public function test_can_load_collection_with_member_field()
+    {
+        $collectionData = file_get_contents(__DIR__ . '/../fixtures/collection-member-field.json');
+        $collection = Collection::fromJson($collectionData);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals(12, sizeof($collection->getManifests()));
+        $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
+
+        $this->assertEquals('', $collection->getLabel());
+    }
+
+    public function test_is_collection()
+    {
+        $collection1 = json_decode(file_get_contents(__DIR__ . '/../fixtures/collection-member-field.json'), true);
+        $this->assertTrue(Collection::isCollection($collection1));
+
+        $collection2 = json_decode(file_get_contents(__DIR__ . '/../fixtures/collection-manifest-field.json'), true);
+        $this->assertTrue(Collection::isCollection($collection2));
+
+        $manifest1 = json_decode(file_get_contents(__DIR__ . '/../fixtures/manifest-a.json'), true);
+        $this->assertFalse(Collection::isCollection($manifest1));
+
+        $manifest2 = json_decode(file_get_contents(__DIR__ . '/../fixtures/manifest-b.json'), true);
+        $this->assertFalse(Collection::isCollection($manifest2));
+    }
+
+}

--- a/tests/model/ManifestTest.php
+++ b/tests/model/ManifestTest.php
@@ -3,6 +3,7 @@
 namespace IIIF\Tests\Model;
 
 use IIIF\Model\Image;
+use IIIF\Model\LazyManifest;
 use IIIF\Model\Manifest;
 use IIIF\Model\Region;
 use PHPUnit\Framework\TestCase;
@@ -82,6 +83,30 @@ class ManifestTest extends TestCase
         $firstImage = $images[0];
         $url = $firstImage->getImageService()->getRegion(Region::create(500, 500, 50, 50));
         $this->assertEquals('https://dlcs-ida.org/iiif-img/2/1/M-1473_R-18_0003/500,500,50,50/256,256/0/default.jpg', $url);
+    }
+
+    public function test_is_manifest()
+    {
+        $manifest1 = json_decode(file_get_contents(__DIR__ . '/../fixtures/manifest-a.json'), true);
+        $this->assertTrue(Manifest::isManifest($manifest1));
+
+        $manifest2 = json_decode(file_get_contents(__DIR__ . '/../fixtures/manifest-b.json'), true);
+        $this->assertTrue(Manifest::isManifest($manifest2));
+
+        $collection1 = json_decode(file_get_contents(__DIR__ . '/../fixtures/collection-member-field.json'), true);
+        $this->assertFalse(Manifest::isManifest($collection1));
+
+        $collection2 = json_decode(file_get_contents(__DIR__ . '/../fixtures/collection-manifest-field.json'), true);
+        $this->assertFalse(Manifest::isManifest($collection2));
+    }
+
+    public function test_lazy_manifest()
+    {
+        $manifest = LazyManifest::fromArray([
+            '@id' => __DIR__ . '/../fixtures/manifest-a.json'
+        ]);
+        $thumbnails = $manifest->getThumbnails();
+        $this->assertNotEmpty($thumbnails);
     }
 
 }


### PR DESCRIPTION
See tests for usage, won't recursively load manifests until they are used. Simple loader so you can swap out for something like Guzzle if required, but `file_get_contents` by default.

Also added methods:

`Collection::isCollection(array $data);`
and 
`Manifest::isManifest(array $data);`

for identifying resources for the IIIF Import module