### PR TITLE
Added tests for Wellcome manifests and collections

### DIFF
--- a/src/Model/ImageResource.php
+++ b/src/Model/ImageResource.php
@@ -30,13 +30,17 @@ class ImageResource
 
     public static function fromArray($resource) : self
     {
+        $service = $resource['service'];
+        $service['width'] = $service['width'] ?? $resource['width'];
+        $service['height'] = $service['height'] ?? $resource['height'];
+
         return new static(
             $resource['@id'],
             $resource['@type'] ?? null,
             $resource['format'] ?? null,
             $resource['height'] ?? 0,
             $resource['width'] ?? 0,
-            isset($resource['service']) ? ImageService::fromArray($resource['service']) : null
+            isset($resource['service']) ? ImageService::fromArray($service) : null
         );
     }
 

--- a/tests/fixtures/http/00aba3aa781b1356500a733a9207516e
+++ b/tests/fixtures/http/00aba3aa781b1356500a733a9207516e
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11598803/manifest",
+  "@type": "sc:Manifest",
+  "label": "A monster being fed baskets of infants and excreting them with horns; symbolising vaccination and its effects. Etching by C. Williams, 1802(?).",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A monster being fed baskets of infants and excreting them with horns; symbolising vaccination and its effects. Etching by C. Williams, 1802(?)."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Williams, Charles"
+    },
+    {
+      "label": "Description",
+      "value": "A print published as propaganda against the introduction of vaccination as a preventitive measure against smallpox. Smallpox was once a common epidemic disease that killed, blinded or disfigured its victims. In the 18th century its impact was reduced in Europe by a Chinese practice called variolation, the injection of smallpox fluid from an infected human being into a healthy human. Variolation became a popular practice in Great Britain. In 1798 Edward Jenner (1749-1823) proposed a modification of variolation called vaccination, which involved the injection of fluid from an infected cow into human beings. The introduction of the cow into human medicine seemed irrational and surprising, and was one of the points made against vaccination by its opponents. Some of the opponents of vaccination are named on the obelisk shown on the right of the print: the topmost name is that of Dr Benjamin Moseley, physician to the Royal Hospital at Chelsea. On the left the vaccinators, sporting bull's horns, feed babies to the Vaccination monster, which has the forefeet of a lion and the hindfeet of a cow"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159880'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11598803",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11598803.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11598803",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11598803",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11598803-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11598803",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11598803, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11598803/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11598803/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11598803/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f/full/100,80/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 824,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 80
+                },
+                {
+                  "width": 200,
+                  "height": 161
+                },
+                {
+                  "width": 400,
+                  "height": 322
+                },
+                {
+                  "width": 1024,
+                  "height": 824
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2436,
+          "width": 3028,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11598803/imageanno/f1f113b7-be9b-492a-8411-8b43c90d004f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 824,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11598803/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/0171f5b9d8ebcda599a64ca9a78ca767
+++ b/tests/fixtures/http/0171f5b9d8ebcda599a64ca9a78ca767
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11599509/manifest",
+  "@type": "sc:Manifest",
+  "label": "An operator treating the carbuncled nose of an obese patient with \"Perkins's tractors\". Coloured aquatint after J. Gillray, 1801.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "An operator treating the carbuncled nose of an obese patient with \"Perkins's tractors\". Coloured aquatint after J. Gillray, 1801."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Gillray, James"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159950'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11599509",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11599509.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11599509",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11599509",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11599509-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11599509",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11599509, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11599509/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11599509/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11599509/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25",
+              "protocol": "http://iiif.io/api/image",
+              "height": 804,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 157
+                },
+                {
+                  "width": 400,
+                  "height": 314
+                },
+                {
+                  "width": 1024,
+                  "height": 804
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 5781,
+          "width": 7366,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11599509/imageanno/53e2e36d-ce2f-47b1-9cab-db861580aa25",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 804,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11599509/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/017536fcbaf838922ae72d2c4260d217
+++ b/tests/fixtures/http/017536fcbaf838922ae72d2c4260d217
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11603562/manifest",
+  "@type": "sc:Manifest",
+  "label": "An alchemist using a crown-shaped bellows to blow the flames of a furnace and heat a glass vessel in which the House of Commons is distilled; representing the dissolution of parliament by Pitt. Coloured etching by J. Gillray, 1796.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "An alchemist using a crown-shaped bellows to blow the flames of a furnace and heat a glass vessel in which the House of Commons is distilled; representing the dissolution of parliament by Pitt. Coloured etching by J. Gillray, 1796."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Gillray, James"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1160356'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11603562",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11603562.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11603562",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11603562",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11603562-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11603562",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11603562, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11603562/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11603562/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11603562/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7600,
+          "width": 5701,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11603562/imageanno/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11603562/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/03df70f4e85644abec441df372b28057
+++ b/tests/fixtures/http/03df70f4e85644abec441df372b28057
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11602399/manifest",
+  "@type": "sc:Manifest",
+  "label": "A woman dropping her porcelain tea-cup in horror upon discovering the monstrous contents of a magnified drop of Thames water; revealing the impurity of London drinking water. Coloured etching by W. Heath, 1828.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A woman dropping her porcelain tea-cup in horror upon discovering the monstrous contents of a magnified drop of Thames water; revealing the impurity of London drinking water. Coloured etching by W. Heath, 1828."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Heath, William"
+    },
+    {
+      "label": "Description",
+      "value": "The caricature shows a woman in fashionable dress looking into a microscope to observe  little monsters swimming about in a drop of London Thames water. In the 1820s much of the drinking water of Londoners came from the river Thames, and the sewers emptied into the Thames. A Commission on the London Water Supply was appointed to investigate this dangerous situation, and it reported in 1828. After that report, the five water companies which served the north bank of the river improved their supplies by building reservoirs etc., but the people of Southwark (on the south bank of the river) continued to receive infected water. The problems were not solved until the 1860s when London's present sewerage system was installed by the Metropolitan Board of Works (MBW) and its engineer Joseph Bazalgette. Between the date of this caricature (1828) and the completion of the MBW sewers, London suffered two cholera epidemics, one in 1832 (part of the world pandemic of cholera) and one in 1854. Looking at a drop of water though a microscope was a popular entertainment provided by travelling showmen who carried the microscopes around in cases on their backs"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1160239'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11602399",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11602399.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11602399",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11602399",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11602399-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11602399",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11602399, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11602399/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11602399/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11602399/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5/full/100,68/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 696,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 68
+                },
+                {
+                  "width": 200,
+                  "height": 136
+                },
+                {
+                  "width": 400,
+                  "height": 272
+                },
+                {
+                  "width": 1024,
+                  "height": 696
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2370,
+          "width": 3485,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11602399/imageanno/c45bce25-c327-466e-baf2-5b2ac31b96b5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 696,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11602399/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/1125eae10076232ec6671ecc311d8ac9
+++ b/tests/fixtures/http/1125eae10076232ec6671ecc311d8ac9
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11617457/manifest",
+  "@type": "sc:Manifest",
+  "label": "Phrenological head of Sir Robert Peel as Prime Minister of the United Kingdom. Lithograph, ca. 1844.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Phrenological head of Sir Robert Peel as Prime Minister of the United Kingdom. Lithograph, ca. 1844."
+    },
+    {
+      "label": "Description",
+      "value": "The lettering refers to the phrenological organ allocated to each section of the head. 1. Benevolence: Peel stands on a platform holding corn before a crowd of supplicants. 2. Secretiveness: Peel stands astride a locked trunk marked \"Peel's opinions\". 3. Firmness: Peel, keeling over backwards, is pushed upright by the Duke of Wellington and Queen Victoria. 4. Adhesiveness: a blank space, suggesting lack of steadfastness. 5. Distructiveness [sic]: Peel applies a syphon marked \"Income tax\" to the side of a bull which has a name-tag \"Taxes\". 6. Comparison: before election Peel goes down on bended knee to beseech the electors, while after election they go down on bended knee to beseech him. 7. Wonder: Peel ponders his future. 8. Hope: Peel as a Jack o'Lantern leads the manufacturers into a swamp by holding out a lantern marked \"Protection\". 9. Cautiousness: Peel stands blindfolded in front of bales marked \"League\" (i.e. Anti-Corn Law League) and \"State trials\". 10. Language: Peel as a three-headed statue saying \"Yes\" (left), \"No\" (right), and \"I reserve my opinion\" (centre)"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1161745'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11617457",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11617457.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11617457",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11617457",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11617457-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11617457",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11617457, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11617457/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11617457/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11617457/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 712,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 712,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3316,
+          "width": 2307,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11617457/imageanno/1a62f439-99cd-4780-9868-3b5df335e81e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 712,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11617457/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/1a612286b6d3dddd73e4d347fc904118
+++ b/tests/fixtures/http/1a612286b6d3dddd73e4d347fc904118
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11589723/manifest",
+  "@type": "sc:Manifest",
+  "label": "A quack doctor irresponsibly dispensing his potions. Coloured lithograph.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A quack doctor irresponsibly dispensing his potions. Coloured lithograph."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1158972'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11589723",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11589723.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11589723",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11589723",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11589723-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11589723",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11589723, Digicode: digpathways(Collectors), Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11589723/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11589723/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11589723/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991/full/63,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 642,
+              "sizes": [
+                {
+                  "width": 63,
+                  "height": 100
+                },
+                {
+                  "width": 125,
+                  "height": 200
+                },
+                {
+                  "width": 251,
+                  "height": 400
+                },
+                {
+                  "width": 642,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3396,
+          "width": 2130,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11589723/imageanno/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 642,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11589723/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/1e13e34e97550163662a27dda161ec85
+++ b/tests/fixtures/http/1e13e34e97550163662a27dda161ec85
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11598761/manifest",
+  "@type": "sc:Manifest",
+  "label": "Edward Jenner vaccinating patients in the Smallpox and Inoculation Hospital at St. Pancras: the patients develop features of cows. Coloured etching by J. Gillray, 1802.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Edward Jenner vaccinating patients in the Smallpox and Inoculation Hospital at St. Pancras: the patients develop features of cows. Coloured etching by J. Gillray, 1802."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Gillray, James"
+    },
+    {
+      "label": "Description",
+      "value": "Patients are spoon-fed \"opening mixture\" as they come through the door. A boy standing next to Jenner is holding his pot labelled \"vaccine pock hot from ye cow\", on his jacket is a badge saying \"Pancras\" and in his pocket a paper entitled \"Benefits of the vaccine process\""
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159876'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11598761",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11598761.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11598761",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11598761",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11598761-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11598761",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11598761, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11598761/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11598761/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11598761/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7/full/100,71/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 725,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 71
+                },
+                {
+                  "width": 200,
+                  "height": 142
+                },
+                {
+                  "width": 400,
+                  "height": 283
+                },
+                {
+                  "width": 1024,
+                  "height": 725
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2320,
+          "width": 3276,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11598761/imageanno/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 725,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11598761/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/23e8f4b14a9046d8bc742a8e29c6075f
+++ b/tests/fixtures/http/23e8f4b14a9046d8bc742a8e29c6075f
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11759380/manifest",
+  "@type": "sc:Manifest",
+  "label": "A woman covers her eyes as she steals the teeth of a hanged man. Aquatint with etching by F. Goya, ca. 1797.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A woman covers her eyes as she steals the teeth of a hanged man. Aquatint with etching by F. Goya, ca. 1797."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Goya, Francisco"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175938'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11759380",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11759380.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759380",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11759380",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11759380-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11759380",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11759380, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759380/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11759380/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11759380/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 716,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3370,
+          "width": 2356,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11759380/imageanno/4359f99e-bfe7-488d-ad71-ae29a183b92b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11759380/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/2557f364683fb92d4d3aa85337247bf7
+++ b/tests/fixtures/http/2557f364683fb92d4d3aa85337247bf7
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11746828/manifest",
+  "@type": "sc:Manifest",
+  "label": "An exotic doctor magnetises a young woman; her husband looks on. Lithograph by C. Jacque, c. 1843.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "An exotic doctor magnetises a young woman; her husband looks on. Lithograph by C. Jacque, c. 1843."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Jacque, Charles Emile"
+    },
+    {
+      "label": "Description",
+      "value": "The painting on the wall depicts an old nurse and a man bending towards her"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1174682'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11746828",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11746828.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11746828",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11746828",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11746828-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11746828",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11746828, Digicode: digpathways(Mindcraft), Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11746828/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11746828/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11746828/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 784,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 784,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3054,
+          "width": 2338,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11746828/imageanno/776dac2d-177a-463f-be61-2af87fa1723e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11746828/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/266cd9d780012d011f3c69b93bed59f2
+++ b/tests/fixtures/http/266cd9d780012d011f3c69b93bed59f2
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11894945/manifest",
+  "@type": "sc:Manifest",
+  "label": "A man so engrossed in news of the French Revolution that he unwittingly sets his wig alight with his candle. Etching, 1789.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A man so engrossed in news of the French Revolution that he unwittingly sets his wig alight with his candle. Etching, 1789."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1189494'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11894945",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11894945.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11894945",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11894945",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11894945-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11894945",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11894945, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11894945/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11894945/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11894945/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200/full/82,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 838,
+              "sizes": [
+                {
+                  "width": 82,
+                  "height": 100
+                },
+                {
+                  "width": 164,
+                  "height": 200
+                },
+                {
+                  "width": 327,
+                  "height": 400
+                },
+                {
+                  "width": 838,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3078,
+          "width": 2518,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11894945/imageanno/ebdb2d63-b0c0-4f6c-bd96-27a35d889200",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 838,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11894945/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/28fb4da803e0bd07500e4387f39c4b9b
+++ b/tests/fixtures/http/28fb4da803e0bd07500e4387f39c4b9b
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b29357998/manifest",
+  "@type": "sc:Manifest",
+  "label": "Caricatural Mediaeval / Renaissance medical practitioners.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Caricatural Mediaeval / Renaissance medical practitioners."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Kuijper, Madeleine; Madeleine Kuijper Illustraties; Wellcome Images"
+    },
+    {
+      "label": "Description",
+      "value": "Four scenes of caricatural Mediaeval/Renaissance medical practitioners, digital illustration.  <p>This illustration is inspired by works of mediaeval artists and Dutch 15th century Master-painter Jheronimus Bosch. Each of the four scenes is separated by Aesculapian snakes, referring to the staff of Aesculapius (also known as Asclepius), the God of medicine in ancient Greek mythology. The staff and snakes can also be seen in the modern day medicine symbol. <p>Imaging technique: inkdrawing, digitally colored. Scale: 25.9 x 22 cm (L x W)\n\nDescriptions of the images (clockwise, from top left): <p>1) A parody on the practise of alchemy, a masked bird-like figure holds a conical flask in his hand from which frogs jump out. In the distance a heron waits for his chance to grab one.  <p>2) A poor man sits on a cart in a medieval town square. With his limbs out of place and holding his head in his hands, he appears to be asking a doctor if things can be repaired. On the right a doctor with a bird-mask ponders the situation. Further away some surprised town-folk and a Pinocchio-like figure with a broken leg comes hobbling closer.  <p>3) In another operation scene, the doctor appears to be pulling a bunch of sausages out of a patient's belly, whilst a hurdle of hungry dogs surrounds them.  <p>4) A mediaeval surgeon holding a small knife is operating in a sitting mańs opened head. In the meanwhile the patient is being attended to by a female assistant of the doctor, who is giving him some tea."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb2935799'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b29357998",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b29357998.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b29357998",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b29357998",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b29357998-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b29357998",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b29357998, Digicode: digbiomed, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29357998/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b29357998/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29357998/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8/full/85,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 869,
+              "sizes": [
+                {
+                  "width": 85,
+                  "height": 100
+                },
+                {
+                  "width": 170,
+                  "height": 200
+                },
+                {
+                  "width": 339,
+                  "height": 400
+                },
+                {
+                  "width": 869,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3157,
+          "width": 2678,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29357998/imageanno/73ebe57c-26f0-4d02-bf54-177bc22055b8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 869,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29357998/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/2be9496390a8027d30cccabc451631c2
+++ b/tests/fixtures/http/2be9496390a8027d30cccabc451631c2
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11835151/manifest",
+  "@type": "sc:Manifest",
+  "label": "A nightwatchman disturbs a body-snatcher who has dropped the stolen corpse he had been carrying in a hamper, while the anatomist runs away. Etching with engraving by W. Austin, 1773.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A nightwatchman disturbs a body-snatcher who has dropped the stolen corpse he had been carrying in a hamper, while the anatomist runs away. Etching with engraving by W. Austin, 1773."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Austin, William"
+    },
+    {
+      "label": "Description",
+      "value": "A nightwatchman, carrying a large lantern, has seized the body-snatcher by the shoulder and sounds a rattle in his raised right hand. A female corpse in its burial shroud falls out of the hamper in which it had been carried before being dropped. The body-snatcher tries to pass on the blame by pointing to the fleeing anatomist, who runs away to the right with a skull in the crook of his arm\n\nThe rise of private anatomy schools in eighteenth-century London saw an increase in the demand for cadavers for dissection and this in turn led to the employment of \"Resurrectionists\", body-snatchers who would steal corpses for use in the new schools. One of these schools was run by William Hunter (1718-1783) and he is referred to in this print by the dropped piece of paper inscribed \"Hunter's lectu<res>\". M.D. George in the British Museum catalogue (loc. cit.) describes the running man as \"a lean man in a doctor's tie-wig\" and identifies him as William Hunter himself. For other satires on William Hunter and his anatomy school and museum, see the Wellcome Library catalogue, nos 25405i and 25435i"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1183515'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11835151",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11835151.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11835151",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11835151",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11835151-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11835151",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11835151, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11835151/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11835151/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11835151/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd/full/100,71/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd",
+              "protocol": "http://iiif.io/api/image",
+              "height": 727,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 71
+                },
+                {
+                  "width": 200,
+                  "height": 142
+                },
+                {
+                  "width": 400,
+                  "height": 284
+                },
+                {
+                  "width": 1024,
+                  "height": 727
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 5604,
+          "width": 7888,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11835151/imageanno/0eeca15a-8387-4203-b342-48200c591ecd",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 727,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11835151/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/2cb81d69fc25d92e4798d18c7828f688
+++ b/tests/fixtures/http/2cb81d69fc25d92e4798d18c7828f688
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11600299/manifest",
+  "@type": "sc:Manifest",
+  "label": "A decrepit man screaming in pain from gout, rheumatism and catarrh; represented as three tormenting devils. Coloured etching by J. Cawse, 1809, after G.M. Woodward.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A decrepit man screaming in pain from gout, rheumatism and catarrh; represented as three tormenting devils. Coloured etching by J. Cawse, 1809, after G.M. Woodward."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M; Cawse, John"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1160029'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11600299",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11600299.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11600299",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11600299",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11600299-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11600299",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11600299, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11600299/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11600299/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11600299/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7624,
+          "width": 5844,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11600299/imageanno/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11600299/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/2e933de58902cc55576c03e0280429ec
+++ b/tests/fixtures/http/2e933de58902cc55576c03e0280429ec
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b1165711x/manifest",
+  "@type": "sc:Manifest",
+  "label": "Chang and Eng the Siamese twins, eating and drinking to excess. Coloured etching by W. Heath, 1829.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Chang and Eng the Siamese twins, eating and drinking to excess. Coloured etching by W. Heath, 1829."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Heath, William"
+    },
+    {
+      "label": "Description",
+      "value": "These conjoined-twins are the original Siamese twins, from whom the name derives. Born at Maklong near Bankok in Siam in about May 1811, of Chinese extraction; they were taken to America and then England in 1829, where they were exhibited causing great excitement. They were placed under the medical charge of G.B. Bolton, M.R.C.S., who made extensive observations along with others at the time. After visiting the principal cities in Europe they returned to America to settle as farmers in North Carolina, adopting the name of Bunker and marrying two sisters who bore each of them many healthy children. In 1869 they made another tour through Europe and took advice from eminent surgeons of Britain and France on the feasibility of being separated, with no ultimate conclusion. After having returned to their dual families (which they kept in separate houses) Chang developed bronchitis, which led to their death in mid-January 1874.\n\nFor sitter see: C.J.S. Thompson, 'The mystery and lore of monsters', London 1930; L. Fiedler, 'Freaks', New York 1978; G.M. Gould and W. Pyle, 'Anomalies and curiosities of medicine', Philadelphia 1896, pp. 151-154"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1165711'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b1165711x",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b1165711x.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b1165711x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b1165711x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b1165711x-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b1165711x",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b1165711x, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1165711x/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b1165711x/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b1165711x/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134/full/100,66/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134",
+              "protocol": "http://iiif.io/api/image",
+              "height": 680,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 66
+                },
+                {
+                  "width": 200,
+                  "height": 133
+                },
+                {
+                  "width": 400,
+                  "height": 266
+                },
+                {
+                  "width": 1024,
+                  "height": 680
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 5175,
+          "width": 7788,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b1165711x/imageanno/2ef0161c-0145-4424-ad3a-8c883282b134",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 680,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b1165711x/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/2f134101f5e6a3d1a3ca38bbb2516c48
+++ b/tests/fixtures/http/2f134101f5e6a3d1a3ca38bbb2516c48
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11879853/manifest",
+  "@type": "sc:Manifest",
+  "label": "A barber's shop. Coloured etching with aquatint by T. Rowlandson, 178-, after W.H. Bunbury.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A barber's shop. Coloured etching with aquatint by T. Rowlandson, 178-, after W.H. Bunbury."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Bunbury, Henry William; Rowlandson, Thomas"
+    },
+    {
+      "label": "Description",
+      "value": "In the centre a man is seated, swathed in a sheet while a boy on the left applies tongs to his hair, which a man on the right is combing. On the left two men admire their freshly curled hair in the mirror. On the extreme right a barber shaves a man next to whom stands a man who stanches a cut on his cheek with a towel. In the left-hand foreground a seated customer reads a newspaper with a concerned expression"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1187985'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11879853",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11879853.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11879853",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11879853",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11879853-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11879853",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11879853, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11879853/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11879853/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11879853/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691/full/100,72/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691",
+              "protocol": "http://iiif.io/api/image",
+              "height": 740,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 72
+                },
+                {
+                  "width": 200,
+                  "height": 144
+                },
+                {
+                  "width": 400,
+                  "height": 289
+                },
+                {
+                  "width": 1024,
+                  "height": 740
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2379,
+          "width": 3294,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11879853/imageanno/624be8f0-abb1-4a76-93e0-966337409691",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 740,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11879853/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/36804a3e186c1d3552bee8ee636a0954
+++ b/tests/fixtures/http/36804a3e186c1d3552bee8ee636a0954
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11672420/manifest",
+  "@type": "sc:Manifest",
+  "label": "Physicians expressing their thanks to influenza. Coloured etching attributed to Temple West, 1803.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Physicians expressing their thanks to influenza. Coloured etching attributed to Temple West, 1803."
+    },
+    {
+      "label": "Author(s)",
+      "value": "West, Temple"
+    },
+    {
+      "label": "Description",
+      "value": "The physicians are identified as Sir W. Farquar (kneeling in front); J. Ware (wearing spectacles); R. Pearson (presenting the address with Farquar); Sir G. Baker (bowing low behind Farquar); M. Garthshore or alternatively Sir William Knighton  (standing at right); G.Pearson (the agitated man in the centre of the group); T. Beddoes (back left); W. Falconer (right of Beddoes); Sir George Smith Gibbes (extreme right). The figure of influenza is represented as a French visitor to England."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1167242'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11672420",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11672420.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11672420",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11672420",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11672420-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11672420",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11672420, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11672420/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11672420/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11672420/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f/full/100,70/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 720,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 70
+                },
+                {
+                  "width": 200,
+                  "height": 141
+                },
+                {
+                  "width": 400,
+                  "height": 281
+                },
+                {
+                  "width": 1024,
+                  "height": 720
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 5599,
+          "width": 7964,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11672420/imageanno/0869932c-6f96-4a49-beba-9cf5e3b49f0f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 720,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11672420/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/372a32e03a6349a9ad54842ec8519c01
+++ b/tests/fixtures/http/372a32e03a6349a9ad54842ec8519c01
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11950791/manifest",
+  "@type": "sc:Manifest",
+  "label": "A futuristic vision: the advance of technology leads to rapid transport, sophisticated tastes among the masses, mechanization, and extravagant building projects. Coloured etching by W. Heath, 1829.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A futuristic vision: the advance of technology leads to rapid transport, sophisticated tastes among the masses, mechanization, and extravagant building projects. Coloured etching by W. Heath, 1829."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Heath, William"
+    },
+    {
+      "label": "Description",
+      "value": "Rapid transport: passengers travel on a model horse driven by steam; a postman equipped with wings travels by air; a steam-powered waggon travels between Bath and London in six hours; a pneumatic tube takes passengers from Greenwich Hill to Bengal; there is a suspension bridge between Bengal and Cape Town; a giant flying fish takes convicts from England to New South Wales; Irish emigrants are fired from a cannon; etc.\n\nMechanization: boot-polishing and shaving are powered by steam; bodies are lifted by crane up on the roof of a church for burial in order to foil body-snatchers\n\nSophisticated tastes among the masses: dustmen eat icecream and pineapples; cat's meat is called \"delicate viands for quadrupeds\"; a street-vendor sits under a tasselled parasol reading fiction. A tombstone marking the grave of the \"Select Vestry\" is decorated with dining implements, implying that the introduction of local government elections will stop aldermen etc. from extravagant dining at public expense\n\nExtravagant building projects: Marble Arch and Buckingham Palace; a church with Chinese, Indian and Gothic features; literally building castles in the air to pay off the national debt"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1195079'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11950791",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11950791.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11950791",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11950791",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11950791-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11950791",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11950791, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11950791/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11950791/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11950791/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5/full/100,71/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 731,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 71
+                },
+                {
+                  "width": 200,
+                  "height": 143
+                },
+                {
+                  "width": 400,
+                  "height": 285
+                },
+                {
+                  "width": 1024,
+                  "height": 731
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2311,
+          "width": 3238,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11950791/imageanno/96d33b64-a267-4e7d-86b6-24c24cc775f5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 731,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11950791/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/3ea167fecb6a51c3d823c7fd3a6a46c4
+++ b/tests/fixtures/http/3ea167fecb6a51c3d823c7fd3a6a46c4
@@ -1,0 +1,22012 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b29353427/manifest",
+  "@type": "sc:Manifest",
+  "label": "The Indian Charivari album : vol. 1.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "The Indian Charivari album :"
+    },
+    {
+      "label": "Publication date",
+      "value": "[1875]"
+    },
+    {
+      "label": "Summary",
+      "value": "Collection of 87 portraits / caricatures of statesmen, military types and major public figures of the day in imperial India accompanied bya page of text giving biographical details and information about their work or post."
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb2935342'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "This work has been identified as being free of known restrictions under copyright law, including all related and neighbouring rights and is being made available under the <a target=\"_top\" href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons, Public Domain Mark</a>.<br/><br/>You can copy, modify, distribute and perform the work, even for commercial purposes, without asking permission."
+    }
+  ],
+  "license": "https://creativecommons.org/publicdomain/mark/1.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b29353427",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b29353427.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b29353427",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b29353427",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b29353427-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://iiif.io/api/search/0/context.json",
+      "@id": "https://wellcomelibrary.org/annoservices/search/b29353427",
+      "profile": "http://iiif.io/api/search/0/search",
+      "label": "Search within this manifest",
+      "service": {
+        "@id": "https://wellcomelibrary.org/annoservices/autocomplete/b29353427",
+        "profile": "http://iiif.io/api/search/0/autocomplete",
+        "label": "Get suggested words in this manifest"
+      }
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b29353427",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: monograph, Institution: n/a, Identifier: b29353427, Digicode: dig19th, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29353427/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": [
+        {
+          "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b29353427/0",
+          "format": "application/pdf",
+          "label": "Download as PDF"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/service/fulltext/b29353427/0?raw=true",
+          "format": "text/plain",
+          "label": "Download raw text"
+        }
+      ],
+      "viewingHint": "paged",
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 809,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 316,
+                  "height": 400
+                },
+                {
+                  "width": 809,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=0",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3740,
+          "width": 2956,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ddf9b319-7fd5-4a0c-bd24-15694508c01f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 809,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c0"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/0",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c1",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a2d5b557-d740-4984-b698-69abac9aa906/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a2d5b557-d740-4984-b698-69abac9aa906",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=1",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a2d5b557-d740-4984-b698-69abac9aa906",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a2d5b557-d740-4984-b698-69abac9aa906/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a2d5b557-d740-4984-b698-69abac9aa906",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c1"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/1",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c2",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/43b62c9a-bcd0-4569-835a-c3947af60b45/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/43b62c9a-bcd0-4569-835a-c3947af60b45",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=2",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3806,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/43b62c9a-bcd0-4569-835a-c3947af60b45",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/43b62c9a-bcd0-4569-835a-c3947af60b45/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/43b62c9a-bcd0-4569-835a-c3947af60b45",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c2"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/2",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c3",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/44d91764-bcef-488b-a0df-b721779991e9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/44d91764-bcef-488b-a0df-b721779991e9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 788,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 788,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=3",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3798,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/44d91764-bcef-488b-a0df-b721779991e9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/44d91764-bcef-488b-a0df-b721779991e9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 788,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/44d91764-bcef-488b-a0df-b721779991e9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c3"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/3",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c4",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ea173b6f-9a8c-4584-9fbc-1e8ebbee5948/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ea173b6f-9a8c-4584-9fbc-1e8ebbee5948",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 789,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 789,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=4",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3796,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ea173b6f-9a8c-4584-9fbc-1e8ebbee5948",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ea173b6f-9a8c-4584-9fbc-1e8ebbee5948/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 789,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ea173b6f-9a8c-4584-9fbc-1e8ebbee5948",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c4"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/4",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c5",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/05eb0235-3471-49e7-82bd-0827f078eb89/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/05eb0235-3471-49e7-82bd-0827f078eb89",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=5",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/05eb0235-3471-49e7-82bd-0827f078eb89",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/05eb0235-3471-49e7-82bd-0827f078eb89/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/05eb0235-3471-49e7-82bd-0827f078eb89",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c5"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/5",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c6",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e196a89e-1639-4114-8319-17443df0b9e9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e196a89e-1639-4114-8319-17443df0b9e9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 789,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 789,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=6",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3862,
+          "width": 2977,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e196a89e-1639-4114-8319-17443df0b9e9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e196a89e-1639-4114-8319-17443df0b9e9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 789,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e196a89e-1639-4114-8319-17443df0b9e9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c6"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/6",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c7",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e4409080-139f-4df1-90f1-def21cac744d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e4409080-139f-4df1-90f1-def21cac744d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=7",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e4409080-139f-4df1-90f1-def21cac744d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e4409080-139f-4df1-90f1-def21cac744d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e4409080-139f-4df1-90f1-def21cac744d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c7"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/7",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c8",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1530f731-78b5-4155-a279-56ec44fea6aa/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1530f731-78b5-4155-a279-56ec44fea6aa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 807,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 315,
+                  "height": 400
+                },
+                {
+                  "width": 807,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=8",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 3077,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1530f731-78b5-4155-a279-56ec44fea6aa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1530f731-78b5-4155-a279-56ec44fea6aa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 807,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1530f731-78b5-4155-a279-56ec44fea6aa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c8"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/8",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c9",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/08b59658-3e34-467d-be2c-efc0ae41cc08/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/08b59658-3e34-467d-be2c-efc0ae41cc08",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=9",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/08b59658-3e34-467d-be2c-efc0ae41cc08",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/08b59658-3e34-467d-be2c-efc0ae41cc08/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/08b59658-3e34-467d-be2c-efc0ae41cc08",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c9"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/9",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c10",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/aea06426-117d-4010-90cf-d8cbc7f8d9b0/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/aea06426-117d-4010-90cf-d8cbc7f8d9b0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=10",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3804,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/aea06426-117d-4010-90cf-d8cbc7f8d9b0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/aea06426-117d-4010-90cf-d8cbc7f8d9b0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/aea06426-117d-4010-90cf-d8cbc7f8d9b0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c10"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/10",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c11",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c65186c6-276c-4367-9819-30c3c4a9d0dd/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c65186c6-276c-4367-9819-30c3c4a9d0dd",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=11",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c65186c6-276c-4367-9819-30c3c4a9d0dd",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c65186c6-276c-4367-9819-30c3c4a9d0dd/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c65186c6-276c-4367-9819-30c3c4a9d0dd",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c11"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/11",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c12",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3cda9273-0bb9-43fa-9c63-bc3bfcd58c85/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3cda9273-0bb9-43fa-9c63-bc3bfcd58c85",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=12",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/3cda9273-0bb9-43fa-9c63-bc3bfcd58c85",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3cda9273-0bb9-43fa-9c63-bc3bfcd58c85/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3cda9273-0bb9-43fa-9c63-bc3bfcd58c85",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c12"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/12",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c13",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0ff74b02-98a3-4ca9-bfab-5c8baf0434ee/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0ff74b02-98a3-4ca9-bfab-5c8baf0434ee",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=13",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0ff74b02-98a3-4ca9-bfab-5c8baf0434ee",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0ff74b02-98a3-4ca9-bfab-5c8baf0434ee/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0ff74b02-98a3-4ca9-bfab-5c8baf0434ee",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c13"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/13",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c14",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/617333e0-8a37-4ff6-9851-76983fdc1b5d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/617333e0-8a37-4ff6-9851-76983fdc1b5d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=14",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/617333e0-8a37-4ff6-9851-76983fdc1b5d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/617333e0-8a37-4ff6-9851-76983fdc1b5d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/617333e0-8a37-4ff6-9851-76983fdc1b5d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c14"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/14",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c15",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/83315c6d-4dc5-48c8-801c-4e038fbbdd5e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/83315c6d-4dc5-48c8-801c-4e038fbbdd5e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=15",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/83315c6d-4dc5-48c8-801c-4e038fbbdd5e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/83315c6d-4dc5-48c8-801c-4e038fbbdd5e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/83315c6d-4dc5-48c8-801c-4e038fbbdd5e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c15"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/15",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c16",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5d0cc50a-6194-462c-93b8-dbf44a99aa6a/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5d0cc50a-6194-462c-93b8-dbf44a99aa6a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 755,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=16",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3895,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5d0cc50a-6194-462c-93b8-dbf44a99aa6a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5d0cc50a-6194-462c-93b8-dbf44a99aa6a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5d0cc50a-6194-462c-93b8-dbf44a99aa6a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c16"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/16",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c17",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0670647b-bed3-4451-873f-4ccaed563242/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0670647b-bed3-4451-873f-4ccaed563242",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=17",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0670647b-bed3-4451-873f-4ccaed563242",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0670647b-bed3-4451-873f-4ccaed563242/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0670647b-bed3-4451-873f-4ccaed563242",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c17"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/17",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c18",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5a68a542-59c0-4485-b0b3-e918956faf8e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5a68a542-59c0-4485-b0b3-e918956faf8e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=18",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5a68a542-59c0-4485-b0b3-e918956faf8e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5a68a542-59c0-4485-b0b3-e918956faf8e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5a68a542-59c0-4485-b0b3-e918956faf8e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c18"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/18",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c19",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5c818d18-b2dd-4c04-a925-25813cb6e46b/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5c818d18-b2dd-4c04-a925-25813cb6e46b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=19",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5c818d18-b2dd-4c04-a925-25813cb6e46b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5c818d18-b2dd-4c04-a925-25813cb6e46b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5c818d18-b2dd-4c04-a925-25813cb6e46b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c19"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/19",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c20",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/68aaebcb-2e6b-4ed3-a6c6-e98ecb5f3cc3/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/68aaebcb-2e6b-4ed3-a6c6-e98ecb5f3cc3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=20",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3851,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/68aaebcb-2e6b-4ed3-a6c6-e98ecb5f3cc3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/68aaebcb-2e6b-4ed3-a6c6-e98ecb5f3cc3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/68aaebcb-2e6b-4ed3-a6c6-e98ecb5f3cc3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c20"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/20",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c21",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2e24167a-ac2a-42df-a180-bf51b306c01c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2e24167a-ac2a-42df-a180-bf51b306c01c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=21",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2e24167a-ac2a-42df-a180-bf51b306c01c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2e24167a-ac2a-42df-a180-bf51b306c01c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2e24167a-ac2a-42df-a180-bf51b306c01c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c21"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/21",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c22",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/badd9cb8-d326-4c7a-8f7c-0d2423c682b0/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/badd9cb8-d326-4c7a-8f7c-0d2423c682b0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=22",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/badd9cb8-d326-4c7a-8f7c-0d2423c682b0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/badd9cb8-d326-4c7a-8f7c-0d2423c682b0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/badd9cb8-d326-4c7a-8f7c-0d2423c682b0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c22"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/22",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c23",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0825a74a-cfdc-44d0-9696-0ac89c8b2e11/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0825a74a-cfdc-44d0-9696-0ac89c8b2e11",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=23",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3889,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0825a74a-cfdc-44d0-9696-0ac89c8b2e11",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0825a74a-cfdc-44d0-9696-0ac89c8b2e11/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0825a74a-cfdc-44d0-9696-0ac89c8b2e11",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c23"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/23",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c24",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8be29e75-1ff5-4038-9d41-3dd3a6916fb0/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8be29e75-1ff5-4038-9d41-3dd3a6916fb0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 758,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 758,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=24",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3910,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8be29e75-1ff5-4038-9d41-3dd3a6916fb0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8be29e75-1ff5-4038-9d41-3dd3a6916fb0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 758,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8be29e75-1ff5-4038-9d41-3dd3a6916fb0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c24"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/24",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c25",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ac11edd6-c21f-4b2f-9c0f-fd339238b475/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ac11edd6-c21f-4b2f-9c0f-fd339238b475",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=25",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ac11edd6-c21f-4b2f-9c0f-fd339238b475",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ac11edd6-c21f-4b2f-9c0f-fd339238b475/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ac11edd6-c21f-4b2f-9c0f-fd339238b475",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c25"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/25",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c26",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/941c7c06-4995-4ab9-9405-e275515d24aa/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/941c7c06-4995-4ab9-9405-e275515d24aa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=26",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/941c7c06-4995-4ab9-9405-e275515d24aa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/941c7c06-4995-4ab9-9405-e275515d24aa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/941c7c06-4995-4ab9-9405-e275515d24aa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c26"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/26",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c27",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/39fd5c9d-1071-4008-8ff3-264fb4b29def/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/39fd5c9d-1071-4008-8ff3-264fb4b29def",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=27",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/39fd5c9d-1071-4008-8ff3-264fb4b29def",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/39fd5c9d-1071-4008-8ff3-264fb4b29def/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/39fd5c9d-1071-4008-8ff3-264fb4b29def",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c27"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/27",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c28",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2edead72-3dca-4c28-9b52-971164252b0f/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2edead72-3dca-4c28-9b52-971164252b0f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=28",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3844,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2edead72-3dca-4c28-9b52-971164252b0f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2edead72-3dca-4c28-9b52-971164252b0f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2edead72-3dca-4c28-9b52-971164252b0f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c28"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/28",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c29",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0c69327f-1067-4b25-8571-5e264afd7a11/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0c69327f-1067-4b25-8571-5e264afd7a11",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=29",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0c69327f-1067-4b25-8571-5e264afd7a11",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0c69327f-1067-4b25-8571-5e264afd7a11/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0c69327f-1067-4b25-8571-5e264afd7a11",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c29"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/29",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c30",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c1d1b96a-6970-464c-9267-157dc20804dc/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c1d1b96a-6970-464c-9267-157dc20804dc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=30",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3812,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c1d1b96a-6970-464c-9267-157dc20804dc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c1d1b96a-6970-464c-9267-157dc20804dc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c1d1b96a-6970-464c-9267-157dc20804dc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c30"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/30",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c31",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cd921418-cf7a-4ad7-89ff-0b8c24a4827b/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cd921418-cf7a-4ad7-89ff-0b8c24a4827b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=31",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3897,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/cd921418-cf7a-4ad7-89ff-0b8c24a4827b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cd921418-cf7a-4ad7-89ff-0b8c24a4827b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cd921418-cf7a-4ad7-89ff-0b8c24a4827b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c31"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/31",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c32",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5cb93ad3-a995-4267-9e64-cc671c07fb06/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5cb93ad3-a995-4267-9e64-cc671c07fb06",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 749,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 293,
+                  "height": 400
+                },
+                {
+                  "width": 749,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=32",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3902,
+          "width": 2855,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5cb93ad3-a995-4267-9e64-cc671c07fb06",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5cb93ad3-a995-4267-9e64-cc671c07fb06/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 749,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5cb93ad3-a995-4267-9e64-cc671c07fb06",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c32"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/32",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c33",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2a36100f-1293-4dde-a7f9-40fbac21c847/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2a36100f-1293-4dde-a7f9-40fbac21c847",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=33",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2a36100f-1293-4dde-a7f9-40fbac21c847",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2a36100f-1293-4dde-a7f9-40fbac21c847/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2a36100f-1293-4dde-a7f9-40fbac21c847",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c33"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/33",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c34",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/20267a78-3c7b-4153-a97b-a32f734d40b4/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/20267a78-3c7b-4153-a97b-a32f734d40b4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=34",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/20267a78-3c7b-4153-a97b-a32f734d40b4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/20267a78-3c7b-4153-a97b-a32f734d40b4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/20267a78-3c7b-4153-a97b-a32f734d40b4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c34"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/34",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c35",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a383ed9c-f4d2-445d-a314-8080800ee5ea/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a383ed9c-f4d2-445d-a314-8080800ee5ea",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=35",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3920,
+          "width": 2962,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a383ed9c-f4d2-445d-a314-8080800ee5ea",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a383ed9c-f4d2-445d-a314-8080800ee5ea/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a383ed9c-f4d2-445d-a314-8080800ee5ea",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c35"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/35",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c36",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4dbfec61-6eec-48dd-97c9-64790587bb4e/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4dbfec61-6eec-48dd-97c9-64790587bb4e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 729,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=36",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3871,
+          "width": 2756,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4dbfec61-6eec-48dd-97c9-64790587bb4e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4dbfec61-6eec-48dd-97c9-64790587bb4e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4dbfec61-6eec-48dd-97c9-64790587bb4e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c36"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/36",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c37",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6f9f92c5-51b6-4539-b4b0-88067aa7f33e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6f9f92c5-51b6-4539-b4b0-88067aa7f33e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=37",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6f9f92c5-51b6-4539-b4b0-88067aa7f33e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6f9f92c5-51b6-4539-b4b0-88067aa7f33e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6f9f92c5-51b6-4539-b4b0-88067aa7f33e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c37"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/37",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c38",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9e83f31d-396f-4392-9980-969ef41aafb0/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9e83f31d-396f-4392-9980-969ef41aafb0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=38",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9e83f31d-396f-4392-9980-969ef41aafb0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9e83f31d-396f-4392-9980-969ef41aafb0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9e83f31d-396f-4392-9980-969ef41aafb0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c38"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/38",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c39",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a177e297-cc16-43db-8c42-4d1eb90ce228/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a177e297-cc16-43db-8c42-4d1eb90ce228",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=39",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3879,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a177e297-cc16-43db-8c42-4d1eb90ce228",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a177e297-cc16-43db-8c42-4d1eb90ce228/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a177e297-cc16-43db-8c42-4d1eb90ce228",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c39"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/39",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c40",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2b363066-7f69-4ba8-b02f-4944fbd55497/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2b363066-7f69-4ba8-b02f-4944fbd55497",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 750,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 293,
+                  "height": 400
+                },
+                {
+                  "width": 750,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=40",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3876,
+          "width": 2840,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2b363066-7f69-4ba8-b02f-4944fbd55497",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2b363066-7f69-4ba8-b02f-4944fbd55497/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 750,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2b363066-7f69-4ba8-b02f-4944fbd55497",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c40"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/40",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c41",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a46fc79c-271e-4cdf-b8df-77f0f65960a3/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a46fc79c-271e-4cdf-b8df-77f0f65960a3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=41",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a46fc79c-271e-4cdf-b8df-77f0f65960a3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a46fc79c-271e-4cdf-b8df-77f0f65960a3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a46fc79c-271e-4cdf-b8df-77f0f65960a3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c41"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/41",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c42",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7e9500a1-b78e-4d64-b00f-5f0981c72299/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7e9500a1-b78e-4d64-b00f-5f0981c72299",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=42",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7e9500a1-b78e-4d64-b00f-5f0981c72299",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7e9500a1-b78e-4d64-b00f-5f0981c72299/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7e9500a1-b78e-4d64-b00f-5f0981c72299",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c42"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/42",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c43",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8d4e8e15-e6c7-4e1e-ab60-ac41e00f5111/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8d4e8e15-e6c7-4e1e-ab60-ac41e00f5111",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 762,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=43",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3928,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8d4e8e15-e6c7-4e1e-ab60-ac41e00f5111",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8d4e8e15-e6c7-4e1e-ab60-ac41e00f5111/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8d4e8e15-e6c7-4e1e-ab60-ac41e00f5111",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c43"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/43",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c44",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0f120de1-4892-439a-b7bf-54a3c60a2ca3/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0f120de1-4892-439a-b7bf-54a3c60a2ca3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=44",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3841,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0f120de1-4892-439a-b7bf-54a3c60a2ca3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0f120de1-4892-439a-b7bf-54a3c60a2ca3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0f120de1-4892-439a-b7bf-54a3c60a2ca3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c44"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/44",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c45",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c81b6810-23e0-486e-8f58-b450b85e815e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c81b6810-23e0-486e-8f58-b450b85e815e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=45",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c81b6810-23e0-486e-8f58-b450b85e815e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c81b6810-23e0-486e-8f58-b450b85e815e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c81b6810-23e0-486e-8f58-b450b85e815e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c45"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/45",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c46",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/91241554-0712-44f1-b3e3-ca5211e24443/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/91241554-0712-44f1-b3e3-ca5211e24443",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=46",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3810,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/91241554-0712-44f1-b3e3-ca5211e24443",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/91241554-0712-44f1-b3e3-ca5211e24443/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/91241554-0712-44f1-b3e3-ca5211e24443",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c46"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/46",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c47",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/40399a40-bc26-4453-9452-c235875bc150/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/40399a40-bc26-4453-9452-c235875bc150",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 767,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=47",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/40399a40-bc26-4453-9452-c235875bc150",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/40399a40-bc26-4453-9452-c235875bc150/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/40399a40-bc26-4453-9452-c235875bc150",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c47"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/47",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c48",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/23f2adfc-3cbc-4db8-981e-b073ca8d26fc/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/23f2adfc-3cbc-4db8-981e-b073ca8d26fc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 742,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 742,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=48",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3898,
+          "width": 2825,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/23f2adfc-3cbc-4db8-981e-b073ca8d26fc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/23f2adfc-3cbc-4db8-981e-b073ca8d26fc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/23f2adfc-3cbc-4db8-981e-b073ca8d26fc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c48"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/48",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c49",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a81f0a59-3bfe-4a9a-9712-68213926f2f1/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a81f0a59-3bfe-4a9a-9712-68213926f2f1",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=49",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a81f0a59-3bfe-4a9a-9712-68213926f2f1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a81f0a59-3bfe-4a9a-9712-68213926f2f1/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a81f0a59-3bfe-4a9a-9712-68213926f2f1",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c49"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/49",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c50",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0893d56e-19be-490f-a734-9f0bb074f0e4/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0893d56e-19be-490f-a734-9f0bb074f0e4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=50",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3804,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0893d56e-19be-490f-a734-9f0bb074f0e4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0893d56e-19be-490f-a734-9f0bb074f0e4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0893d56e-19be-490f-a734-9f0bb074f0e4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c50"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/50",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c51",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/27d02820-e4d3-46c1-a4a5-89acbc8a17c2/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/27d02820-e4d3-46c1-a4a5-89acbc8a17c2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 784,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 784,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=51",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3919,
+          "width": 3000,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/27d02820-e4d3-46c1-a4a5-89acbc8a17c2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/27d02820-e4d3-46c1-a4a5-89acbc8a17c2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/27d02820-e4d3-46c1-a4a5-89acbc8a17c2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c51"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/51",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c52",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/49fd658e-0090-4450-9fe6-54cfdcd4d4bb/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/49fd658e-0090-4450-9fe6-54cfdcd4d4bb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=52",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3830,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/49fd658e-0090-4450-9fe6-54cfdcd4d4bb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/49fd658e-0090-4450-9fe6-54cfdcd4d4bb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/49fd658e-0090-4450-9fe6-54cfdcd4d4bb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c52"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/52",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c53",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/290d82e9-62dd-4533-8ba6-4a5f0113aa76/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/290d82e9-62dd-4533-8ba6-4a5f0113aa76",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=53",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/290d82e9-62dd-4533-8ba6-4a5f0113aa76",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/290d82e9-62dd-4533-8ba6-4a5f0113aa76/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/290d82e9-62dd-4533-8ba6-4a5f0113aa76",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c53"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/53",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c54",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7a24a2ee-a4ae-432f-b646-ed770959066f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7a24a2ee-a4ae-432f-b646-ed770959066f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=54",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7a24a2ee-a4ae-432f-b646-ed770959066f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7a24a2ee-a4ae-432f-b646-ed770959066f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7a24a2ee-a4ae-432f-b646-ed770959066f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c54"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/54",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c55",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/43d2c615-cf2b-4232-9d42-fdd85e1757b9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/43d2c615-cf2b-4232-9d42-fdd85e1757b9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=55",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/43d2c615-cf2b-4232-9d42-fdd85e1757b9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/43d2c615-cf2b-4232-9d42-fdd85e1757b9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/43d2c615-cf2b-4232-9d42-fdd85e1757b9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c55"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/55",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c56",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/983a37d9-82f5-468a-a7f6-53cd69df658a/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/983a37d9-82f5-468a-a7f6-53cd69df658a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 754,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=56",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3858,
+          "width": 2841,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/983a37d9-82f5-468a-a7f6-53cd69df658a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/983a37d9-82f5-468a-a7f6-53cd69df658a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/983a37d9-82f5-468a-a7f6-53cd69df658a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c56"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/56",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c57",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/72a8bc85-2e76-46cf-b32f-ba1aa516d758/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/72a8bc85-2e76-46cf-b32f-ba1aa516d758",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=57",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/72a8bc85-2e76-46cf-b32f-ba1aa516d758",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/72a8bc85-2e76-46cf-b32f-ba1aa516d758/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/72a8bc85-2e76-46cf-b32f-ba1aa516d758",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c57"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/57",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c58",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/84e52d20-6f2c-400f-a515-34080d823038/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/84e52d20-6f2c-400f-a515-34080d823038",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=58",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/84e52d20-6f2c-400f-a515-34080d823038",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/84e52d20-6f2c-400f-a515-34080d823038/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/84e52d20-6f2c-400f-a515-34080d823038",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c58"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/58",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c59",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3ddc17a7-9dc3-4896-a266-a3440c58fe54/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3ddc17a7-9dc3-4896-a266-a3440c58fe54",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=59",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/3ddc17a7-9dc3-4896-a266-a3440c58fe54",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3ddc17a7-9dc3-4896-a266-a3440c58fe54/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3ddc17a7-9dc3-4896-a266-a3440c58fe54",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c59"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/59",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c60",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/709993c5-8e02-444e-b322-c93d89db874f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/709993c5-8e02-444e-b322-c93d89db874f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=60",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/709993c5-8e02-444e-b322-c93d89db874f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/709993c5-8e02-444e-b322-c93d89db874f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/709993c5-8e02-444e-b322-c93d89db874f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c60"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/60",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c61",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d891e691-9e8b-4ddc-aa56-563e6531e6ac/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d891e691-9e8b-4ddc-aa56-563e6531e6ac",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=61",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d891e691-9e8b-4ddc-aa56-563e6531e6ac",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d891e691-9e8b-4ddc-aa56-563e6531e6ac/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d891e691-9e8b-4ddc-aa56-563e6531e6ac",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c61"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/61",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c62",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8dc45ac4-ca88-4f82-9461-8b988c250a31/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8dc45ac4-ca88-4f82-9461-8b988c250a31",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=62",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8dc45ac4-ca88-4f82-9461-8b988c250a31",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8dc45ac4-ca88-4f82-9461-8b988c250a31/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8dc45ac4-ca88-4f82-9461-8b988c250a31",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c62"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/62",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c63",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/10146467-343e-4ebb-8f5e-3e0b54dea76f/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/10146467-343e-4ebb-8f5e-3e0b54dea76f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=63",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3874,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/10146467-343e-4ebb-8f5e-3e0b54dea76f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/10146467-343e-4ebb-8f5e-3e0b54dea76f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/10146467-343e-4ebb-8f5e-3e0b54dea76f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c63"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/63",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c64",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a7fef246-847b-4206-b2bf-a8a2a698241a/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a7fef246-847b-4206-b2bf-a8a2a698241a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=64",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3848,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a7fef246-847b-4206-b2bf-a8a2a698241a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a7fef246-847b-4206-b2bf-a8a2a698241a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a7fef246-847b-4206-b2bf-a8a2a698241a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c64"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/64",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c65",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fa96a3fa-30c7-46fd-9427-a3182ee04339/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fa96a3fa-30c7-46fd-9427-a3182ee04339",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=65",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fa96a3fa-30c7-46fd-9427-a3182ee04339",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fa96a3fa-30c7-46fd-9427-a3182ee04339/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fa96a3fa-30c7-46fd-9427-a3182ee04339",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c65"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/65",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c66",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cfd6c8f1-2f7c-4c59-8871-2a69e279d585/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cfd6c8f1-2f7c-4c59-8871-2a69e279d585",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=66",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/cfd6c8f1-2f7c-4c59-8871-2a69e279d585",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cfd6c8f1-2f7c-4c59-8871-2a69e279d585/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cfd6c8f1-2f7c-4c59-8871-2a69e279d585",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c66"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/66",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c67",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7c4c2f05-a848-45a9-b985-a07c29998393/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7c4c2f05-a848-45a9-b985-a07c29998393",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=67",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3811,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7c4c2f05-a848-45a9-b985-a07c29998393",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7c4c2f05-a848-45a9-b985-a07c29998393/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7c4c2f05-a848-45a9-b985-a07c29998393",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c67"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/67",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c68",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/aa32a64a-f5f2-44be-a142-2246923790d2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/aa32a64a-f5f2-44be-a142-2246923790d2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 758,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 758,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=68",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3827,
+          "width": 2832,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/aa32a64a-f5f2-44be-a142-2246923790d2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/aa32a64a-f5f2-44be-a142-2246923790d2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 758,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/aa32a64a-f5f2-44be-a142-2246923790d2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c68"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/68",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c69",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/60b2f7a3-f384-48ab-89a3-5b1e21bb193a/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/60b2f7a3-f384-48ab-89a3-5b1e21bb193a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=69",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/60b2f7a3-f384-48ab-89a3-5b1e21bb193a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/60b2f7a3-f384-48ab-89a3-5b1e21bb193a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/60b2f7a3-f384-48ab-89a3-5b1e21bb193a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c69"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/69",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c70",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b54bf100-e199-41c2-b8ac-cde7ae252339/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b54bf100-e199-41c2-b8ac-cde7ae252339",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=70",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b54bf100-e199-41c2-b8ac-cde7ae252339",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b54bf100-e199-41c2-b8ac-cde7ae252339/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b54bf100-e199-41c2-b8ac-cde7ae252339",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c70"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/70",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c71",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8c34a60c-fa88-4592-80b1-53e496a69b94/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8c34a60c-fa88-4592-80b1-53e496a69b94",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=71",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8c34a60c-fa88-4592-80b1-53e496a69b94",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8c34a60c-fa88-4592-80b1-53e496a69b94/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8c34a60c-fa88-4592-80b1-53e496a69b94",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c71"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/71",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c72",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fd99c8d8-e646-455e-8764-3235a3c42e22/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fd99c8d8-e646-455e-8764-3235a3c42e22",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 756,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=72",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3857,
+          "width": 2848,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fd99c8d8-e646-455e-8764-3235a3c42e22",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fd99c8d8-e646-455e-8764-3235a3c42e22/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fd99c8d8-e646-455e-8764-3235a3c42e22",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c72"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/72",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c73",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5860ea9a-0c6d-49f1-a15f-cd84d9efa7a1/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5860ea9a-0c6d-49f1-a15f-cd84d9efa7a1",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=73",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5860ea9a-0c6d-49f1-a15f-cd84d9efa7a1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5860ea9a-0c6d-49f1-a15f-cd84d9efa7a1/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5860ea9a-0c6d-49f1-a15f-cd84d9efa7a1",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c73"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/73",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c74",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/657dc1bd-79a8-4fc0-95f9-5a5f7a663219/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/657dc1bd-79a8-4fc0-95f9-5a5f7a663219",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=74",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/657dc1bd-79a8-4fc0-95f9-5a5f7a663219",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/657dc1bd-79a8-4fc0-95f9-5a5f7a663219/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/657dc1bd-79a8-4fc0-95f9-5a5f7a663219",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c74"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/74",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c75",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f5c81850-c063-488f-840b-3cea84203df4/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f5c81850-c063-488f-840b-3cea84203df4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=75",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3882,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f5c81850-c063-488f-840b-3cea84203df4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f5c81850-c063-488f-840b-3cea84203df4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f5c81850-c063-488f-840b-3cea84203df4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c75"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/75",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c76",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f378e3c7-0412-43d1-bf11-6f8225f3dc64/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f378e3c7-0412-43d1-bf11-6f8225f3dc64",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 748,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=76",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3832,
+          "width": 2801,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f378e3c7-0412-43d1-bf11-6f8225f3dc64",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f378e3c7-0412-43d1-bf11-6f8225f3dc64/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f378e3c7-0412-43d1-bf11-6f8225f3dc64",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c76"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/76",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c77",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6384b612-9be9-4003-9dfb-3083261385a6/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6384b612-9be9-4003-9dfb-3083261385a6",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=77",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6384b612-9be9-4003-9dfb-3083261385a6",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6384b612-9be9-4003-9dfb-3083261385a6/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6384b612-9be9-4003-9dfb-3083261385a6",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c77"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/77",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c78",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b18ad9ec-a2e2-4799-9365-42c40cfd06c5/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b18ad9ec-a2e2-4799-9365-42c40cfd06c5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=78",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b18ad9ec-a2e2-4799-9365-42c40cfd06c5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b18ad9ec-a2e2-4799-9365-42c40cfd06c5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b18ad9ec-a2e2-4799-9365-42c40cfd06c5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c78"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/78",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c79",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/77e9c95f-1f8c-42cc-806f-dd515fd0780e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/77e9c95f-1f8c-42cc-806f-dd515fd0780e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=79",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/77e9c95f-1f8c-42cc-806f-dd515fd0780e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/77e9c95f-1f8c-42cc-806f-dd515fd0780e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/77e9c95f-1f8c-42cc-806f-dd515fd0780e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c79"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/79",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c80",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/442f3aff-656e-47eb-914f-0d03f0a0e91c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/442f3aff-656e-47eb-914f-0d03f0a0e91c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=80",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/442f3aff-656e-47eb-914f-0d03f0a0e91c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/442f3aff-656e-47eb-914f-0d03f0a0e91c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/442f3aff-656e-47eb-914f-0d03f0a0e91c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c80"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/80",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c81",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7ba01360-1983-4fff-848c-92e99d0700ac/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7ba01360-1983-4fff-848c-92e99d0700ac",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=81",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7ba01360-1983-4fff-848c-92e99d0700ac",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7ba01360-1983-4fff-848c-92e99d0700ac/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7ba01360-1983-4fff-848c-92e99d0700ac",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c81"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/81",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c82",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fedd85cd-8194-4926-8a81-99f2b2015f14/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fedd85cd-8194-4926-8a81-99f2b2015f14",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=82",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fedd85cd-8194-4926-8a81-99f2b2015f14",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fedd85cd-8194-4926-8a81-99f2b2015f14/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fedd85cd-8194-4926-8a81-99f2b2015f14",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c82"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/82",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c83",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/709a9aa4-3b1e-43ad-aa9e-eeb6a8f693f9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/709a9aa4-3b1e-43ad-aa9e-eeb6a8f693f9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=83",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/709a9aa4-3b1e-43ad-aa9e-eeb6a8f693f9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/709a9aa4-3b1e-43ad-aa9e-eeb6a8f693f9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/709a9aa4-3b1e-43ad-aa9e-eeb6a8f693f9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c83"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/83",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c84",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/469a9177-5a5f-4883-b25a-7f5811e32abf/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/469a9177-5a5f-4883-b25a-7f5811e32abf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=84",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/469a9177-5a5f-4883-b25a-7f5811e32abf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/469a9177-5a5f-4883-b25a-7f5811e32abf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/469a9177-5a5f-4883-b25a-7f5811e32abf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c84"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/84",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c85",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/328a6af9-4a02-455e-96b2-da0d1425b560/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/328a6af9-4a02-455e-96b2-da0d1425b560",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=85",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/328a6af9-4a02-455e-96b2-da0d1425b560",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/328a6af9-4a02-455e-96b2-da0d1425b560/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/328a6af9-4a02-455e-96b2-da0d1425b560",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c85"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/85",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c86",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/03b1ca76-c08e-4868-a938-a419c6ae99df/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/03b1ca76-c08e-4868-a938-a419c6ae99df",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 789,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 789,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=86",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3795,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/03b1ca76-c08e-4868-a938-a419c6ae99df",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/03b1ca76-c08e-4868-a938-a419c6ae99df/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 789,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/03b1ca76-c08e-4868-a938-a419c6ae99df",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c86"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/86",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c87",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5bc43adb-61cb-44be-8268-f033edd888af/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5bc43adb-61cb-44be-8268-f033edd888af",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=87",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5bc43adb-61cb-44be-8268-f033edd888af",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5bc43adb-61cb-44be-8268-f033edd888af/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5bc43adb-61cb-44be-8268-f033edd888af",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c87"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/87",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c88",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0ad478e0-d4d7-4cfc-bb13-e97e85efc6e2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0ad478e0-d4d7-4cfc-bb13-e97e85efc6e2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=88",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3851,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0ad478e0-d4d7-4cfc-bb13-e97e85efc6e2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0ad478e0-d4d7-4cfc-bb13-e97e85efc6e2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0ad478e0-d4d7-4cfc-bb13-e97e85efc6e2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c88"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/88",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c89",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e305dbfb-68f8-4163-8097-9c76f9dc7ded/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e305dbfb-68f8-4163-8097-9c76f9dc7ded",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=89",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e305dbfb-68f8-4163-8097-9c76f9dc7ded",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e305dbfb-68f8-4163-8097-9c76f9dc7ded/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e305dbfb-68f8-4163-8097-9c76f9dc7ded",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c89"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/89",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c90",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2a390400-847d-460b-aa73-5e1caa463873/full/78,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2a390400-847d-460b-aa73-5e1caa463873",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 797,
+              "sizes": [
+                {
+                  "width": 78,
+                  "height": 100
+                },
+                {
+                  "width": 156,
+                  "height": 200
+                },
+                {
+                  "width": 311,
+                  "height": 400
+                },
+                {
+                  "width": 797,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=90",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3757,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2a390400-847d-460b-aa73-5e1caa463873",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2a390400-847d-460b-aa73-5e1caa463873/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 797,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2a390400-847d-460b-aa73-5e1caa463873",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c90"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/90",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c91",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7e71bb7f-d860-4391-a22d-1923d85f4bc3/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7e71bb7f-d860-4391-a22d-1923d85f4bc3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 776,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 776,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=91",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3880,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7e71bb7f-d860-4391-a22d-1923d85f4bc3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7e71bb7f-d860-4391-a22d-1923d85f4bc3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 776,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7e71bb7f-d860-4391-a22d-1923d85f4bc3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c91"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/91",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c92",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/dc128e50-b1c5-431a-b623-92b02f3a8e0f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/dc128e50-b1c5-431a-b623-92b02f3a8e0f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=92",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/dc128e50-b1c5-431a-b623-92b02f3a8e0f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/dc128e50-b1c5-431a-b623-92b02f3a8e0f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dc128e50-b1c5-431a-b623-92b02f3a8e0f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c92"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/92",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c93",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b193540c-a4cb-4925-83d4-447b93dae61f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b193540c-a4cb-4925-83d4-447b93dae61f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=93",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b193540c-a4cb-4925-83d4-447b93dae61f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b193540c-a4cb-4925-83d4-447b93dae61f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b193540c-a4cb-4925-83d4-447b93dae61f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c93"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/93",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c94",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6ed36495-562e-4b17-a55c-ef6d52e70171/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6ed36495-562e-4b17-a55c-ef6d52e70171",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 788,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 788,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=94",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3800,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6ed36495-562e-4b17-a55c-ef6d52e70171",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6ed36495-562e-4b17-a55c-ef6d52e70171/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 788,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6ed36495-562e-4b17-a55c-ef6d52e70171",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c94"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/94",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c95",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/bda8780d-579a-49c3-87df-74c2f2c887e9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/bda8780d-579a-49c3-87df-74c2f2c887e9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=95",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3803,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/bda8780d-579a-49c3-87df-74c2f2c887e9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/bda8780d-579a-49c3-87df-74c2f2c887e9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bda8780d-579a-49c3-87df-74c2f2c887e9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c95"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/95",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c96",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4c2ccb89-5365-4bd7-89e4-9cc16e21eb26/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4c2ccb89-5365-4bd7-89e4-9cc16e21eb26",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 737,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 737,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=96",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3880,
+          "width": 2793,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4c2ccb89-5365-4bd7-89e4-9cc16e21eb26",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4c2ccb89-5365-4bd7-89e4-9cc16e21eb26/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 737,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4c2ccb89-5365-4bd7-89e4-9cc16e21eb26",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c96"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/96",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c97",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f9716a24-f381-4875-a186-fe62b730d28d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f9716a24-f381-4875-a186-fe62b730d28d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=97",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f9716a24-f381-4875-a186-fe62b730d28d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f9716a24-f381-4875-a186-fe62b730d28d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f9716a24-f381-4875-a186-fe62b730d28d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c97"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/97",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c98",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/25075ad5-b977-42bb-8a25-7aebfd2a9e8f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/25075ad5-b977-42bb-8a25-7aebfd2a9e8f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=98",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/25075ad5-b977-42bb-8a25-7aebfd2a9e8f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/25075ad5-b977-42bb-8a25-7aebfd2a9e8f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/25075ad5-b977-42bb-8a25-7aebfd2a9e8f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c98"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/98",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c99",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/70724ee3-166a-463a-888f-54b6a8f56d64/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/70724ee3-166a-463a-888f-54b6a8f56d64",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=99",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/70724ee3-166a-463a-888f-54b6a8f56d64",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/70724ee3-166a-463a-888f-54b6a8f56d64/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/70724ee3-166a-463a-888f-54b6a8f56d64",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c99"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/99",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c100",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6de58329-2ee0-4290-8581-7471d934c8a3/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6de58329-2ee0-4290-8581-7471d934c8a3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=100",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3815,
+          "width": 2878,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6de58329-2ee0-4290-8581-7471d934c8a3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6de58329-2ee0-4290-8581-7471d934c8a3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6de58329-2ee0-4290-8581-7471d934c8a3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c100"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/100",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c101",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e8be2f30-8d07-4151-bcb7-3ccb586d0b5d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e8be2f30-8d07-4151-bcb7-3ccb586d0b5d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=101",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e8be2f30-8d07-4151-bcb7-3ccb586d0b5d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e8be2f30-8d07-4151-bcb7-3ccb586d0b5d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e8be2f30-8d07-4151-bcb7-3ccb586d0b5d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c101"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/101",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c102",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f4193c92-fbf8-4043-a830-ddc5d8261220/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f4193c92-fbf8-4043-a830-ddc5d8261220",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=102",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f4193c92-fbf8-4043-a830-ddc5d8261220",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f4193c92-fbf8-4043-a830-ddc5d8261220/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f4193c92-fbf8-4043-a830-ddc5d8261220",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c102"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/102",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c103",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1d03ead3-4098-4325-bf58-5b6e6cb02323/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1d03ead3-4098-4325-bf58-5b6e6cb02323",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 788,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 788,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=103",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3801,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1d03ead3-4098-4325-bf58-5b6e6cb02323",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1d03ead3-4098-4325-bf58-5b6e6cb02323/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 788,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1d03ead3-4098-4325-bf58-5b6e6cb02323",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c103"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/103",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c104",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/04938120-71fa-4850-9762-5e36aa538aa1/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/04938120-71fa-4850-9762-5e36aa538aa1",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 755,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=104",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3819,
+          "width": 2817,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/04938120-71fa-4850-9762-5e36aa538aa1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/04938120-71fa-4850-9762-5e36aa538aa1/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/04938120-71fa-4850-9762-5e36aa538aa1",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c104"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/104",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c105",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5e573c2c-5a5e-4ba9-bfcc-88e4febd9dda/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5e573c2c-5a5e-4ba9-bfcc-88e4febd9dda",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=105",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5e573c2c-5a5e-4ba9-bfcc-88e4febd9dda",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5e573c2c-5a5e-4ba9-bfcc-88e4febd9dda/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5e573c2c-5a5e-4ba9-bfcc-88e4febd9dda",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c105"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/105",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c106",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/03246879-a4b2-4bc8-8f74-f820c965e19d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/03246879-a4b2-4bc8-8f74-f820c965e19d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=106",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/03246879-a4b2-4bc8-8f74-f820c965e19d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/03246879-a4b2-4bc8-8f74-f820c965e19d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/03246879-a4b2-4bc8-8f74-f820c965e19d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c106"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/106",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c107",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/de67a4c6-ad0d-4a12-ba94-ebdc4b9d2cbb/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/de67a4c6-ad0d-4a12-ba94-ebdc4b9d2cbb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=107",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/de67a4c6-ad0d-4a12-ba94-ebdc4b9d2cbb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/de67a4c6-ad0d-4a12-ba94-ebdc4b9d2cbb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/de67a4c6-ad0d-4a12-ba94-ebdc4b9d2cbb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c107"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/107",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c108",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c5c64566-865b-4847-b864-7dba7553cca4/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c5c64566-865b-4847-b864-7dba7553cca4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=108",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3811,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c5c64566-865b-4847-b864-7dba7553cca4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c5c64566-865b-4847-b864-7dba7553cca4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c5c64566-865b-4847-b864-7dba7553cca4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c108"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/108",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c109",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f2d853e3-8883-499c-9a5e-fbda0ca9df3a/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f2d853e3-8883-499c-9a5e-fbda0ca9df3a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=109",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f2d853e3-8883-499c-9a5e-fbda0ca9df3a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f2d853e3-8883-499c-9a5e-fbda0ca9df3a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f2d853e3-8883-499c-9a5e-fbda0ca9df3a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c109"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/109",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c110",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/60bd0059-3603-41bc-8498-cddf986997b5/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/60bd0059-3603-41bc-8498-cddf986997b5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=110",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/60bd0059-3603-41bc-8498-cddf986997b5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/60bd0059-3603-41bc-8498-cddf986997b5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/60bd0059-3603-41bc-8498-cddf986997b5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c110"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/110",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c111",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5ba99fc2-226f-423e-96cb-e1c0f8ca5a44/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5ba99fc2-226f-423e-96cb-e1c0f8ca5a44",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 773,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=111",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3884,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5ba99fc2-226f-423e-96cb-e1c0f8ca5a44",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5ba99fc2-226f-423e-96cb-e1c0f8ca5a44/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5ba99fc2-226f-423e-96cb-e1c0f8ca5a44",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c111"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/111",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c112",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d8b57899-8677-4d8d-909b-9d9094f7b455/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d8b57899-8677-4d8d-909b-9d9094f7b455",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 766,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=112",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3856,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d8b57899-8677-4d8d-909b-9d9094f7b455",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d8b57899-8677-4d8d-909b-9d9094f7b455/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d8b57899-8677-4d8d-909b-9d9094f7b455",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c112"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/112",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c113",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/96005d4d-d9d9-4285-a54f-a53adb7d3937/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/96005d4d-d9d9-4285-a54f-a53adb7d3937",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=113",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/96005d4d-d9d9-4285-a54f-a53adb7d3937",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/96005d4d-d9d9-4285-a54f-a53adb7d3937/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/96005d4d-d9d9-4285-a54f-a53adb7d3937",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c113"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/113",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c114",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a86bfcba-6f03-4746-b548-f1bc2bbe0f67/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a86bfcba-6f03-4746-b548-f1bc2bbe0f67",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=114",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3811,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a86bfcba-6f03-4746-b548-f1bc2bbe0f67",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a86bfcba-6f03-4746-b548-f1bc2bbe0f67/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a86bfcba-6f03-4746-b548-f1bc2bbe0f67",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c114"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/114",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c115",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c0d77f2a-0a8d-4ac7-a440-60ee0fda544c/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c0d77f2a-0a8d-4ac7-a440-60ee0fda544c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=115",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3858,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c0d77f2a-0a8d-4ac7-a440-60ee0fda544c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c0d77f2a-0a8d-4ac7-a440-60ee0fda544c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c0d77f2a-0a8d-4ac7-a440-60ee0fda544c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c115"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/115",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c116",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f4bdff7e-7fbe-4506-beea-7c3da108dfeb/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f4bdff7e-7fbe-4506-beea-7c3da108dfeb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 757,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 757,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=116",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3852,
+          "width": 2848,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f4bdff7e-7fbe-4506-beea-7c3da108dfeb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f4bdff7e-7fbe-4506-beea-7c3da108dfeb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 757,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f4bdff7e-7fbe-4506-beea-7c3da108dfeb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c116"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/116",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c117",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/12b14f16-d968-40d0-bca2-a065704f8a09/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/12b14f16-d968-40d0-bca2-a065704f8a09",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=117",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/12b14f16-d968-40d0-bca2-a065704f8a09",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/12b14f16-d968-40d0-bca2-a065704f8a09/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/12b14f16-d968-40d0-bca2-a065704f8a09",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c117"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/117",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c118",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/71d0b3d7-697b-4e74-9dcc-d2a933225a83/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/71d0b3d7-697b-4e74-9dcc-d2a933225a83",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=118",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/71d0b3d7-697b-4e74-9dcc-d2a933225a83",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/71d0b3d7-697b-4e74-9dcc-d2a933225a83/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/71d0b3d7-697b-4e74-9dcc-d2a933225a83",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c118"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/118",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c119",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c1f9241f-dcc8-41e6-9b5a-a3a52507627e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c1f9241f-dcc8-41e6-9b5a-a3a52507627e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 784,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 784,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=119",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3812,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c1f9241f-dcc8-41e6-9b5a-a3a52507627e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c1f9241f-dcc8-41e6-9b5a-a3a52507627e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c1f9241f-dcc8-41e6-9b5a-a3a52507627e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c119"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/119",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c120",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6d62eb5f-4ec0-4c51-a3fe-2ef22587a345/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6d62eb5f-4ec0-4c51-a3fe-2ef22587a345",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 784,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 784,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=120",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3812,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6d62eb5f-4ec0-4c51-a3fe-2ef22587a345",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6d62eb5f-4ec0-4c51-a3fe-2ef22587a345/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6d62eb5f-4ec0-4c51-a3fe-2ef22587a345",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c120"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/120",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c121",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/91f32dcb-3f32-44d8-8439-753ae7459c88/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/91f32dcb-3f32-44d8-8439-753ae7459c88",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=121",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/91f32dcb-3f32-44d8-8439-753ae7459c88",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/91f32dcb-3f32-44d8-8439-753ae7459c88/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/91f32dcb-3f32-44d8-8439-753ae7459c88",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c121"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/121",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c122",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ed22c6fb-ad3e-46eb-b633-ba898cd90b37/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ed22c6fb-ad3e-46eb-b633-ba898cd90b37",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=122",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ed22c6fb-ad3e-46eb-b633-ba898cd90b37",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ed22c6fb-ad3e-46eb-b633-ba898cd90b37/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ed22c6fb-ad3e-46eb-b633-ba898cd90b37",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c122"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/122",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c123",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d0d0b1ee-4254-4e6d-b242-3a107837c1f5/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d0d0b1ee-4254-4e6d-b242-3a107837c1f5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=123",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3806,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d0d0b1ee-4254-4e6d-b242-3a107837c1f5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d0d0b1ee-4254-4e6d-b242-3a107837c1f5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d0d0b1ee-4254-4e6d-b242-3a107837c1f5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c123"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/123",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c124",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fd1bc292-14f9-4e15-8948-d3a8fb6f5193/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fd1bc292-14f9-4e15-8948-d3a8fb6f5193",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 754,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=124",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3856,
+          "width": 2840,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fd1bc292-14f9-4e15-8948-d3a8fb6f5193",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fd1bc292-14f9-4e15-8948-d3a8fb6f5193/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fd1bc292-14f9-4e15-8948-d3a8fb6f5193",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c124"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/124",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c125",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0703ea85-62c6-4d4c-bc89-248b18f3940c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0703ea85-62c6-4d4c-bc89-248b18f3940c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=125",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0703ea85-62c6-4d4c-bc89-248b18f3940c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0703ea85-62c6-4d4c-bc89-248b18f3940c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0703ea85-62c6-4d4c-bc89-248b18f3940c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c125"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/125",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c126",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/440dd3d6-0b43-4a2d-8e39-b9cd61bb2cd3/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/440dd3d6-0b43-4a2d-8e39-b9cd61bb2cd3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=126",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/440dd3d6-0b43-4a2d-8e39-b9cd61bb2cd3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/440dd3d6-0b43-4a2d-8e39-b9cd61bb2cd3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/440dd3d6-0b43-4a2d-8e39-b9cd61bb2cd3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c126"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/126",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c127",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a378adba-8912-4b31-a446-d252a3b0a376/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a378adba-8912-4b31-a446-d252a3b0a376",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=127",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a378adba-8912-4b31-a446-d252a3b0a376",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a378adba-8912-4b31-a446-d252a3b0a376/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a378adba-8912-4b31-a446-d252a3b0a376",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c127"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/127",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c128",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9d8012eb-c5a7-4d5a-ae71-7e5aa06d3f77/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9d8012eb-c5a7-4d5a-ae71-7e5aa06d3f77",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=128",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3776,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9d8012eb-c5a7-4d5a-ae71-7e5aa06d3f77",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9d8012eb-c5a7-4d5a-ae71-7e5aa06d3f77/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9d8012eb-c5a7-4d5a-ae71-7e5aa06d3f77",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c128"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/128",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c129",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c6214a46-d14a-42d7-b478-a20e854e17f8/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c6214a46-d14a-42d7-b478-a20e854e17f8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=129",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c6214a46-d14a-42d7-b478-a20e854e17f8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c6214a46-d14a-42d7-b478-a20e854e17f8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c6214a46-d14a-42d7-b478-a20e854e17f8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c129"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/129",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c130",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3716b13e-1789-4ad0-b63d-123de6873578/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3716b13e-1789-4ad0-b63d-123de6873578",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=130",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3808,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/3716b13e-1789-4ad0-b63d-123de6873578",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3716b13e-1789-4ad0-b63d-123de6873578/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3716b13e-1789-4ad0-b63d-123de6873578",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c130"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/130",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c131",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ffd279cc-c05d-42d1-afed-3e3033191cc4/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ffd279cc-c05d-42d1-afed-3e3033191cc4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 782,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 782,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=131",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3829,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ffd279cc-c05d-42d1-afed-3e3033191cc4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ffd279cc-c05d-42d1-afed-3e3033191cc4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 782,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ffd279cc-c05d-42d1-afed-3e3033191cc4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c131"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/131",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c132",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b6e16bda-ca00-4626-af1e-5442c45bddf5/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b6e16bda-ca00-4626-af1e-5442c45bddf5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=132",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3842,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b6e16bda-ca00-4626-af1e-5442c45bddf5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b6e16bda-ca00-4626-af1e-5442c45bddf5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b6e16bda-ca00-4626-af1e-5442c45bddf5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c132"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/132",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c133",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/18ec783d-9b13-4ec5-9e4d-eb04ef124794/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/18ec783d-9b13-4ec5-9e4d-eb04ef124794",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=133",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/18ec783d-9b13-4ec5-9e4d-eb04ef124794",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/18ec783d-9b13-4ec5-9e4d-eb04ef124794/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/18ec783d-9b13-4ec5-9e4d-eb04ef124794",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c133"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/133",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c134",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9e07bdf3-3ee6-44b2-a3d0-c858eb54d47d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9e07bdf3-3ee6-44b2-a3d0-c858eb54d47d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=134",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9e07bdf3-3ee6-44b2-a3d0-c858eb54d47d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9e07bdf3-3ee6-44b2-a3d0-c858eb54d47d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9e07bdf3-3ee6-44b2-a3d0-c858eb54d47d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c134"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/134",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c135",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3574957a-29a3-459d-89f6-23c3a0d3b83d/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3574957a-29a3-459d-89f6-23c3a0d3b83d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 780,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 780,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=135",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/3574957a-29a3-459d-89f6-23c3a0d3b83d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3574957a-29a3-459d-89f6-23c3a0d3b83d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 780,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3574957a-29a3-459d-89f6-23c3a0d3b83d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c135"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/135",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c136",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5a086b99-0a31-4a3f-8a96-151af3753b9b/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5a086b99-0a31-4a3f-8a96-151af3753b9b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 760,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 760,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=136",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5a086b99-0a31-4a3f-8a96-151af3753b9b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5a086b99-0a31-4a3f-8a96-151af3753b9b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 760,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5a086b99-0a31-4a3f-8a96-151af3753b9b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c136"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/136",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c137",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f23f6438-680b-4206-8c8b-7a13a9b97648/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f23f6438-680b-4206-8c8b-7a13a9b97648",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=137",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f23f6438-680b-4206-8c8b-7a13a9b97648",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f23f6438-680b-4206-8c8b-7a13a9b97648/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f23f6438-680b-4206-8c8b-7a13a9b97648",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c137"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/137",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c138",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/494b961d-6978-46d5-8af8-976de897e3ce/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/494b961d-6978-46d5-8af8-976de897e3ce",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 788,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 788,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=138",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3801,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/494b961d-6978-46d5-8af8-976de897e3ce",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/494b961d-6978-46d5-8af8-976de897e3ce/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 788,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/494b961d-6978-46d5-8af8-976de897e3ce",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c138"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/138",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c139",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/09d400a1-51cc-4753-a113-b8be01c51573/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/09d400a1-51cc-4753-a113-b8be01c51573",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=139",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/09d400a1-51cc-4753-a113-b8be01c51573",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/09d400a1-51cc-4753-a113-b8be01c51573/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/09d400a1-51cc-4753-a113-b8be01c51573",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c139"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/139",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c140",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/aad1448d-c2cd-4766-bf28-6e8ca387bfc8/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/aad1448d-c2cd-4766-bf28-6e8ca387bfc8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 763,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=140",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3852,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/aad1448d-c2cd-4766-bf28-6e8ca387bfc8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/aad1448d-c2cd-4766-bf28-6e8ca387bfc8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/aad1448d-c2cd-4766-bf28-6e8ca387bfc8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c140"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/140",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c141",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/89b3335c-3a94-41db-97dc-fb7541eb5590/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/89b3335c-3a94-41db-97dc-fb7541eb5590",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=141",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/89b3335c-3a94-41db-97dc-fb7541eb5590",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/89b3335c-3a94-41db-97dc-fb7541eb5590/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/89b3335c-3a94-41db-97dc-fb7541eb5590",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c141"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/141",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c142",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fee23f66-6b6d-405a-9d76-eea18938d1f6/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fee23f66-6b6d-405a-9d76-eea18938d1f6",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=142",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fee23f66-6b6d-405a-9d76-eea18938d1f6",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fee23f66-6b6d-405a-9d76-eea18938d1f6/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fee23f66-6b6d-405a-9d76-eea18938d1f6",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c142"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/142",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c143",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d807ad85-f71d-4748-a152-ec85868e68b8/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d807ad85-f71d-4748-a152-ec85868e68b8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=143",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d807ad85-f71d-4748-a152-ec85868e68b8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d807ad85-f71d-4748-a152-ec85868e68b8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d807ad85-f71d-4748-a152-ec85868e68b8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c143"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/143",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c144",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/63108688-2513-403b-b112-71f3a49b3b1d/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/63108688-2513-403b-b112-71f3a49b3b1d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=144",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3865,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/63108688-2513-403b-b112-71f3a49b3b1d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/63108688-2513-403b-b112-71f3a49b3b1d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/63108688-2513-403b-b112-71f3a49b3b1d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c144"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/144",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c145",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/bee9a9a0-f305-48d1-99ac-f162e9736215/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/bee9a9a0-f305-48d1-99ac-f162e9736215",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=145",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/bee9a9a0-f305-48d1-99ac-f162e9736215",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/bee9a9a0-f305-48d1-99ac-f162e9736215/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bee9a9a0-f305-48d1-99ac-f162e9736215",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c145"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/145",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c146",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cd83c38a-5b18-4a8a-bf67-ff248561e645/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cd83c38a-5b18-4a8a-bf67-ff248561e645",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=146",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3807,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/cd83c38a-5b18-4a8a-bf67-ff248561e645",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cd83c38a-5b18-4a8a-bf67-ff248561e645/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cd83c38a-5b18-4a8a-bf67-ff248561e645",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c146"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/146",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c147",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/da3d8b80-985d-427c-8787-21a1f34f08c9/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/da3d8b80-985d-427c-8787-21a1f34f08c9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=147",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3854,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/da3d8b80-985d-427c-8787-21a1f34f08c9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/da3d8b80-985d-427c-8787-21a1f34f08c9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/da3d8b80-985d-427c-8787-21a1f34f08c9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c147"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/147",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c148",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/44fc47f2-dcd9-4341-8a31-5ab4661fc346/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/44fc47f2-dcd9-4341-8a31-5ab4661fc346",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 764,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=148",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3869,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/44fc47f2-dcd9-4341-8a31-5ab4661fc346",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/44fc47f2-dcd9-4341-8a31-5ab4661fc346/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/44fc47f2-dcd9-4341-8a31-5ab4661fc346",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c148"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/148",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c149",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ab750743-21a3-4624-9896-c230a840f3ca/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ab750743-21a3-4624-9896-c230a840f3ca",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=149",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ab750743-21a3-4624-9896-c230a840f3ca",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ab750743-21a3-4624-9896-c230a840f3ca/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ab750743-21a3-4624-9896-c230a840f3ca",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c149"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/149",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c150",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d2cfe068-ef15-4bde-8916-c9a563e1dcab/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d2cfe068-ef15-4bde-8916-c9a563e1dcab",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 792,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 155,
+                  "height": 200
+                },
+                {
+                  "width": 309,
+                  "height": 400
+                },
+                {
+                  "width": 792,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=150",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3782,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d2cfe068-ef15-4bde-8916-c9a563e1dcab",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d2cfe068-ef15-4bde-8916-c9a563e1dcab/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 792,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d2cfe068-ef15-4bde-8916-c9a563e1dcab",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c150"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/150",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c151",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5eb1164d-b912-4636-b2dc-ebbbd2eb0aa2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5eb1164d-b912-4636-b2dc-ebbbd2eb0aa2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 776,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 776,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=151",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5eb1164d-b912-4636-b2dc-ebbbd2eb0aa2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5eb1164d-b912-4636-b2dc-ebbbd2eb0aa2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 776,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5eb1164d-b912-4636-b2dc-ebbbd2eb0aa2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c151"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/151",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c152",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a847f15d-2bdf-4f08-ae74-679b0638764b/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a847f15d-2bdf-4f08-ae74-679b0638764b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 777,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 777,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=152",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3830,
+          "width": 2908,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a847f15d-2bdf-4f08-ae74-679b0638764b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a847f15d-2bdf-4f08-ae74-679b0638764b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 777,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a847f15d-2bdf-4f08-ae74-679b0638764b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c152"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/152",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c153",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/52330099-dc82-4333-949d-f51f3999f699/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/52330099-dc82-4333-949d-f51f3999f699",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=153",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/52330099-dc82-4333-949d-f51f3999f699",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/52330099-dc82-4333-949d-f51f3999f699/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/52330099-dc82-4333-949d-f51f3999f699",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c153"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/153",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c154",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4e1cb1df-f05a-48cb-a115-783bd646cc55/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4e1cb1df-f05a-48cb-a115-783bd646cc55",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 788,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 308,
+                  "height": 400
+                },
+                {
+                  "width": 788,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=154",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3801,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4e1cb1df-f05a-48cb-a115-783bd646cc55",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4e1cb1df-f05a-48cb-a115-783bd646cc55/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 788,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4e1cb1df-f05a-48cb-a115-783bd646cc55",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c154"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/154",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c155",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f71e92aa-6c1a-44ac-84b7-8073981c330b/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f71e92aa-6c1a-44ac-84b7-8073981c330b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=155",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3882,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f71e92aa-6c1a-44ac-84b7-8073981c330b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f71e92aa-6c1a-44ac-84b7-8073981c330b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f71e92aa-6c1a-44ac-84b7-8073981c330b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c155"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/155",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c156",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f995f2c4-4fb9-493c-912a-b8d74ee6847f/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f995f2c4-4fb9-493c-912a-b8d74ee6847f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 773,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=156",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3854,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f995f2c4-4fb9-493c-912a-b8d74ee6847f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f995f2c4-4fb9-493c-912a-b8d74ee6847f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f995f2c4-4fb9-493c-912a-b8d74ee6847f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c156"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/156",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c157",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/164efff6-cc41-4e1c-a79d-f1a8533be98a/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/164efff6-cc41-4e1c-a79d-f1a8533be98a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=157",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/164efff6-cc41-4e1c-a79d-f1a8533be98a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/164efff6-cc41-4e1c-a79d-f1a8533be98a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/164efff6-cc41-4e1c-a79d-f1a8533be98a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c157"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/157",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c158",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c49a90ff-1171-458a-a600-1414fb5c57bf/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c49a90ff-1171-458a-a600-1414fb5c57bf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 787,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 787,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=158",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3805,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c49a90ff-1171-458a-a600-1414fb5c57bf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c49a90ff-1171-458a-a600-1414fb5c57bf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 787,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c49a90ff-1171-458a-a600-1414fb5c57bf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c158"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/158",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c159",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ba5cf10d-9c2b-458a-879a-ed168bd4ae80/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ba5cf10d-9c2b-458a-879a-ed168bd4ae80",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=159",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ba5cf10d-9c2b-458a-879a-ed168bd4ae80",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ba5cf10d-9c2b-458a-879a-ed168bd4ae80/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ba5cf10d-9c2b-458a-879a-ed168bd4ae80",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c159"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/159",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c160",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5fd9b5c0-7ef0-49d1-9f8a-f4475492e779/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5fd9b5c0-7ef0-49d1-9f8a-f4475492e779",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 760,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 760,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=160",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3838,
+          "width": 2848,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5fd9b5c0-7ef0-49d1-9f8a-f4475492e779",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5fd9b5c0-7ef0-49d1-9f8a-f4475492e779/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 760,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5fd9b5c0-7ef0-49d1-9f8a-f4475492e779",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c160"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/160",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c161",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/878a3558-face-4022-b295-be5b8c93dedf/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/878a3558-face-4022-b295-be5b8c93dedf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=161",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/878a3558-face-4022-b295-be5b8c93dedf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/878a3558-face-4022-b295-be5b8c93dedf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/878a3558-face-4022-b295-be5b8c93dedf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c161"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/161",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c162",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/34690bc7-6d4d-4090-a5a1-bcd012be8aaf/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/34690bc7-6d4d-4090-a5a1-bcd012be8aaf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=162",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/34690bc7-6d4d-4090-a5a1-bcd012be8aaf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/34690bc7-6d4d-4090-a5a1-bcd012be8aaf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/34690bc7-6d4d-4090-a5a1-bcd012be8aaf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c162"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/162",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c163",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e66598d2-f7d4-41d0-82f6-f0be647f2df4/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e66598d2-f7d4-41d0-82f6-f0be647f2df4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=163",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e66598d2-f7d4-41d0-82f6-f0be647f2df4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e66598d2-f7d4-41d0-82f6-f0be647f2df4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e66598d2-f7d4-41d0-82f6-f0be647f2df4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c163"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/163",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c164",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/586d21bb-02d7-4a14-9d06-08cccb6cacc7/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/586d21bb-02d7-4a14-9d06-08cccb6cacc7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 766,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=164",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3880,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/586d21bb-02d7-4a14-9d06-08cccb6cacc7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/586d21bb-02d7-4a14-9d06-08cccb6cacc7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/586d21bb-02d7-4a14-9d06-08cccb6cacc7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c164"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/164",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c165",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c93b4a77-0a68-4e61-a8b8-d2bea492dd3d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c93b4a77-0a68-4e61-a8b8-d2bea492dd3d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=165",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c93b4a77-0a68-4e61-a8b8-d2bea492dd3d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c93b4a77-0a68-4e61-a8b8-d2bea492dd3d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c93b4a77-0a68-4e61-a8b8-d2bea492dd3d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c165"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/165",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c166",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4b8812b7-7b1c-41dc-8858-5fd49e065188/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4b8812b7-7b1c-41dc-8858-5fd49e065188",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=166",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4b8812b7-7b1c-41dc-8858-5fd49e065188",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4b8812b7-7b1c-41dc-8858-5fd49e065188/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4b8812b7-7b1c-41dc-8858-5fd49e065188",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c166"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/166",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c167",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2b71a00b-0ac3-434a-8d7a-9632376559fa/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2b71a00b-0ac3-434a-8d7a-9632376559fa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 766,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=167",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3889,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2b71a00b-0ac3-434a-8d7a-9632376559fa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2b71a00b-0ac3-434a-8d7a-9632376559fa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2b71a00b-0ac3-434a-8d7a-9632376559fa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c167"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/167",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c168",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/145d582a-d659-4281-aec0-440e6601aa18/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/145d582a-d659-4281-aec0-440e6601aa18",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 759,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 759,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=168",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3834,
+          "width": 2840,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/145d582a-d659-4281-aec0-440e6601aa18",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/145d582a-d659-4281-aec0-440e6601aa18/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 759,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/145d582a-d659-4281-aec0-440e6601aa18",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c168"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/168",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c169",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b8610f4f-8cc7-41cd-ad83-d10f4fc1cbaf/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b8610f4f-8cc7-41cd-ad83-d10f4fc1cbaf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=169",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b8610f4f-8cc7-41cd-ad83-d10f4fc1cbaf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b8610f4f-8cc7-41cd-ad83-d10f4fc1cbaf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b8610f4f-8cc7-41cd-ad83-d10f4fc1cbaf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c169"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/169",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c170",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fbf70252-9aa6-4e1f-baba-7289747eb9cc/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fbf70252-9aa6-4e1f-baba-7289747eb9cc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=170",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fbf70252-9aa6-4e1f-baba-7289747eb9cc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fbf70252-9aa6-4e1f-baba-7289747eb9cc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fbf70252-9aa6-4e1f-baba-7289747eb9cc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c170"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/170",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c171",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d08619c9-f808-4f83-be10-86bbb76503e4/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d08619c9-f808-4f83-be10-86bbb76503e4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=171",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3835,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d08619c9-f808-4f83-be10-86bbb76503e4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d08619c9-f808-4f83-be10-86bbb76503e4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d08619c9-f808-4f83-be10-86bbb76503e4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c171"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/171",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c172",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8b52e896-6bb3-4ec4-9470-affaf8621da7/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8b52e896-6bb3-4ec4-9470-affaf8621da7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=172",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8b52e896-6bb3-4ec4-9470-affaf8621da7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8b52e896-6bb3-4ec4-9470-affaf8621da7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8b52e896-6bb3-4ec4-9470-affaf8621da7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c172"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/172",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c173",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8723e87d-cbb5-4b50-939f-72f2594db95f/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8723e87d-cbb5-4b50-939f-72f2594db95f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=173",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3863,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8723e87d-cbb5-4b50-939f-72f2594db95f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8723e87d-cbb5-4b50-939f-72f2594db95f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8723e87d-cbb5-4b50-939f-72f2594db95f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c173"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/173",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c174",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7e5812f7-3fbb-4262-b6cf-a1a30e111157/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7e5812f7-3fbb-4262-b6cf-a1a30e111157",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 764,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=174",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3836,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7e5812f7-3fbb-4262-b6cf-a1a30e111157",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7e5812f7-3fbb-4262-b6cf-a1a30e111157/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7e5812f7-3fbb-4262-b6cf-a1a30e111157",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c174"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/174",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c175",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/856d4ee2-2fec-4fe9-92fa-1354c777fe57/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/856d4ee2-2fec-4fe9-92fa-1354c777fe57",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=175",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/856d4ee2-2fec-4fe9-92fa-1354c777fe57",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/856d4ee2-2fec-4fe9-92fa-1354c777fe57/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/856d4ee2-2fec-4fe9-92fa-1354c777fe57",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c175"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/175",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c176",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b994c726-0836-44bc-aabd-3bf686b90ddb/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b994c726-0836-44bc-aabd-3bf686b90ddb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=176",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b994c726-0836-44bc-aabd-3bf686b90ddb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b994c726-0836-44bc-aabd-3bf686b90ddb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b994c726-0836-44bc-aabd-3bf686b90ddb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c176"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/176",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c177",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/742fa86c-755c-4e10-b97a-b8edabf3c517/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/742fa86c-755c-4e10-b97a-b8edabf3c517",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=177",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3897,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/742fa86c-755c-4e10-b97a-b8edabf3c517",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/742fa86c-755c-4e10-b97a-b8edabf3c517/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/742fa86c-755c-4e10-b97a-b8edabf3c517",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c177"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/177",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c178",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/711235a7-6ac2-4283-9728-9c65fa26987f/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/711235a7-6ac2-4283-9728-9c65fa26987f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 763,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=178",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3840,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/711235a7-6ac2-4283-9728-9c65fa26987f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/711235a7-6ac2-4283-9728-9c65fa26987f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/711235a7-6ac2-4283-9728-9c65fa26987f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c178"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/178",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c179",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7f4715cf-6e1c-402c-a214-40c7a8861ca7/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7f4715cf-6e1c-402c-a214-40c7a8861ca7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=179",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7f4715cf-6e1c-402c-a214-40c7a8861ca7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7f4715cf-6e1c-402c-a214-40c7a8861ca7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7f4715cf-6e1c-402c-a214-40c7a8861ca7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c179"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/179",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c180",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a06d83cc-ce5f-4519-8981-241cd81b7cf7/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a06d83cc-ce5f-4519-8981-241cd81b7cf7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=180",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a06d83cc-ce5f-4519-8981-241cd81b7cf7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a06d83cc-ce5f-4519-8981-241cd81b7cf7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a06d83cc-ce5f-4519-8981-241cd81b7cf7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c180"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/180",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c181",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/568ba1e4-cde7-4b20-846b-aab067f09036/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/568ba1e4-cde7-4b20-846b-aab067f09036",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=181",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3849,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/568ba1e4-cde7-4b20-846b-aab067f09036",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/568ba1e4-cde7-4b20-846b-aab067f09036/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/568ba1e4-cde7-4b20-846b-aab067f09036",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c181"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/181",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c182",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/10cf1a6f-7d1f-4edc-8de7-94b6b1bab2b4/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/10cf1a6f-7d1f-4edc-8de7-94b6b1bab2b4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=182",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3861,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/10cf1a6f-7d1f-4edc-8de7-94b6b1bab2b4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/10cf1a6f-7d1f-4edc-8de7-94b6b1bab2b4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/10cf1a6f-7d1f-4edc-8de7-94b6b1bab2b4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c182"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/182",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c183",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/581b6124-b334-4dcb-8f70-d4f6f881e1c9/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/581b6124-b334-4dcb-8f70-d4f6f881e1c9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=183",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/581b6124-b334-4dcb-8f70-d4f6f881e1c9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/581b6124-b334-4dcb-8f70-d4f6f881e1c9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/581b6124-b334-4dcb-8f70-d4f6f881e1c9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c183"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/183",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c184",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d94c7123-e53f-4d0d-bc6d-ce395c6cc06a/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d94c7123-e53f-4d0d-bc6d-ce395c6cc06a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=184",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d94c7123-e53f-4d0d-bc6d-ce395c6cc06a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d94c7123-e53f-4d0d-bc6d-ce395c6cc06a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d94c7123-e53f-4d0d-bc6d-ce395c6cc06a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c184"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/184",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c185",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/48a49279-db58-4e9b-9b66-696f15323ecc/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/48a49279-db58-4e9b-9b66-696f15323ecc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=185",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/48a49279-db58-4e9b-9b66-696f15323ecc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/48a49279-db58-4e9b-9b66-696f15323ecc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/48a49279-db58-4e9b-9b66-696f15323ecc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c185"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/185",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c186",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5b22c74c-036b-4c81-95a4-109dc73cfafa/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5b22c74c-036b-4c81-95a4-109dc73cfafa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=186",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3834,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5b22c74c-036b-4c81-95a4-109dc73cfafa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5b22c74c-036b-4c81-95a4-109dc73cfafa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5b22c74c-036b-4c81-95a4-109dc73cfafa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c186"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/186",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c187",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c9015dd9-d280-43d3-b1d0-45030705162b/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c9015dd9-d280-43d3-b1d0-45030705162b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=187",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c9015dd9-d280-43d3-b1d0-45030705162b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c9015dd9-d280-43d3-b1d0-45030705162b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c9015dd9-d280-43d3-b1d0-45030705162b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c187"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/187",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c188",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/542ae277-ab20-4ed5-a97c-747107d6300b/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/542ae277-ab20-4ed5-a97c-747107d6300b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=188",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/542ae277-ab20-4ed5-a97c-747107d6300b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/542ae277-ab20-4ed5-a97c-747107d6300b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/542ae277-ab20-4ed5-a97c-747107d6300b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c188"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/188",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c189",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7faeff9e-5885-459e-aa8f-05af90842ab8/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7faeff9e-5885-459e-aa8f-05af90842ab8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=189",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3805,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7faeff9e-5885-459e-aa8f-05af90842ab8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7faeff9e-5885-459e-aa8f-05af90842ab8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7faeff9e-5885-459e-aa8f-05af90842ab8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c189"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/189",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c190",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/b7fb05ef-e6f9-4c0c-95c6-74b1c9d1df36/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/b7fb05ef-e6f9-4c0c-95c6-74b1c9d1df36",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 757,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 757,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=190",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3884,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/b7fb05ef-e6f9-4c0c-95c6-74b1c9d1df36",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/b7fb05ef-e6f9-4c0c-95c6-74b1c9d1df36/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 757,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b7fb05ef-e6f9-4c0c-95c6-74b1c9d1df36",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c190"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/190",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c191",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4d6284ad-00d9-4942-a0a2-e2a5d95e4dd4/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4d6284ad-00d9-4942-a0a2-e2a5d95e4dd4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=191",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4d6284ad-00d9-4942-a0a2-e2a5d95e4dd4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4d6284ad-00d9-4942-a0a2-e2a5d95e4dd4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4d6284ad-00d9-4942-a0a2-e2a5d95e4dd4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c191"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/191",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c192",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9f19be43-0da0-4a02-9151-ce61e1b43648/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9f19be43-0da0-4a02-9151-ce61e1b43648",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=192",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9f19be43-0da0-4a02-9151-ce61e1b43648",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9f19be43-0da0-4a02-9151-ce61e1b43648/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9f19be43-0da0-4a02-9151-ce61e1b43648",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c192"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/192",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c193",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/81996c71-9083-420b-8137-99e45c0018d7/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/81996c71-9083-420b-8137-99e45c0018d7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 783,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 783,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=193",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3843,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/81996c71-9083-420b-8137-99e45c0018d7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/81996c71-9083-420b-8137-99e45c0018d7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 783,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/81996c71-9083-420b-8137-99e45c0018d7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c193"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/193",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c194",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8f816541-c954-4183-8c36-ea4084610204/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8f816541-c954-4183-8c36-ea4084610204",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 762,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=194",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3857,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8f816541-c954-4183-8c36-ea4084610204",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8f816541-c954-4183-8c36-ea4084610204/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8f816541-c954-4183-8c36-ea4084610204",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c194"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/194",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c195",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1b2f1a42-86f6-4c47-a750-66e7f7a488df/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1b2f1a42-86f6-4c47-a750-66e7f7a488df",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=195",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1b2f1a42-86f6-4c47-a750-66e7f7a488df",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1b2f1a42-86f6-4c47-a750-66e7f7a488df/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1b2f1a42-86f6-4c47-a750-66e7f7a488df",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c195"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/195",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c196",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/19e01317-75e0-4dde-aea9-2151ff3e379f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/19e01317-75e0-4dde-aea9-2151ff3e379f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=196",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/19e01317-75e0-4dde-aea9-2151ff3e379f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/19e01317-75e0-4dde-aea9-2151ff3e379f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/19e01317-75e0-4dde-aea9-2151ff3e379f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c196"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/196",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c197",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/45f1b8b3-7a55-4f30-8996-009bfe715d95/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/45f1b8b3-7a55-4f30-8996-009bfe715d95",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 780,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 780,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=197",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3828,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/45f1b8b3-7a55-4f30-8996-009bfe715d95",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/45f1b8b3-7a55-4f30-8996-009bfe715d95/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 780,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/45f1b8b3-7a55-4f30-8996-009bfe715d95",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c197"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/197",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c198",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a59bcf2a-deb5-4dd0-979b-e08ddb208af4/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a59bcf2a-deb5-4dd0-979b-e08ddb208af4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 764,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=198",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3858,
+          "width": 2878,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a59bcf2a-deb5-4dd0-979b-e08ddb208af4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a59bcf2a-deb5-4dd0-979b-e08ddb208af4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a59bcf2a-deb5-4dd0-979b-e08ddb208af4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c198"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/198",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c199",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/54b3930e-a381-4176-b3e8-abcffce197c7/full/78,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/54b3930e-a381-4176-b3e8-abcffce197c7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 797,
+              "sizes": [
+                {
+                  "width": 78,
+                  "height": 100
+                },
+                {
+                  "width": 156,
+                  "height": 200
+                },
+                {
+                  "width": 311,
+                  "height": 400
+                },
+                {
+                  "width": 797,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=199",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3771,
+          "width": 2936,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/54b3930e-a381-4176-b3e8-abcffce197c7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/54b3930e-a381-4176-b3e8-abcffce197c7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 797,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/54b3930e-a381-4176-b3e8-abcffce197c7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c199"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/199",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c200",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c7a85b1f-d2b3-4c96-8520-d6d05eb8bd2e/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c7a85b1f-d2b3-4c96-8520-d6d05eb8bd2e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=200",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3830,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c7a85b1f-d2b3-4c96-8520-d6d05eb8bd2e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c7a85b1f-d2b3-4c96-8520-d6d05eb8bd2e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c7a85b1f-d2b3-4c96-8520-d6d05eb8bd2e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c200"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/200",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c201",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1a18ef91-c385-4b54-a40f-90167bdd0b7a/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1a18ef91-c385-4b54-a40f-90167bdd0b7a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=201",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3854,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1a18ef91-c385-4b54-a40f-90167bdd0b7a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1a18ef91-c385-4b54-a40f-90167bdd0b7a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1a18ef91-c385-4b54-a40f-90167bdd0b7a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c201"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/201",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c202",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cc042513-73fd-4cf0-ab3e-cb049bba5fee/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cc042513-73fd-4cf0-ab3e-cb049bba5fee",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=202",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3827,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/cc042513-73fd-4cf0-ab3e-cb049bba5fee",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cc042513-73fd-4cf0-ab3e-cb049bba5fee/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cc042513-73fd-4cf0-ab3e-cb049bba5fee",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c202"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/202",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c203",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/552cb57d-c9ac-4107-88b7-23dc85c2fe2d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/552cb57d-c9ac-4107-88b7-23dc85c2fe2d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=203",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/552cb57d-c9ac-4107-88b7-23dc85c2fe2d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/552cb57d-c9ac-4107-88b7-23dc85c2fe2d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/552cb57d-c9ac-4107-88b7-23dc85c2fe2d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c203"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/203",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c204",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7706461c-9476-4e70-a92f-01738ec0d419/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7706461c-9476-4e70-a92f-01738ec0d419",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=204",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7706461c-9476-4e70-a92f-01738ec0d419",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7706461c-9476-4e70-a92f-01738ec0d419/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7706461c-9476-4e70-a92f-01738ec0d419",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c204"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/204",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c205",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5f6318bd-f4c4-4fef-897d-b276f58d101d/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5f6318bd-f4c4-4fef-897d-b276f58d101d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=205",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3887,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5f6318bd-f4c4-4fef-897d-b276f58d101d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5f6318bd-f4c4-4fef-897d-b276f58d101d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5f6318bd-f4c4-4fef-897d-b276f58d101d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c205"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/205",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c206",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/54dcb9ab-902e-4337-8ad0-e4d9654c7170/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/54dcb9ab-902e-4337-8ad0-e4d9654c7170",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=206",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3855,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/54dcb9ab-902e-4337-8ad0-e4d9654c7170",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/54dcb9ab-902e-4337-8ad0-e4d9654c7170/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/54dcb9ab-902e-4337-8ad0-e4d9654c7170",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c206"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/206",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c207",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f2abfc16-713a-4613-9523-79b9cd5addca/full/80,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f2abfc16-713a-4613-9523-79b9cd5addca",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 819,
+              "sizes": [
+                {
+                  "width": 80,
+                  "height": 100
+                },
+                {
+                  "width": 160,
+                  "height": 200
+                },
+                {
+                  "width": 320,
+                  "height": 400
+                },
+                {
+                  "width": 819,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=207",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3048,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f2abfc16-713a-4613-9523-79b9cd5addca",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f2abfc16-713a-4613-9523-79b9cd5addca/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 819,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f2abfc16-713a-4613-9523-79b9cd5addca",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c207"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/207",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c208",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f15b3b91-4b55-4389-8caa-8b4beb38c4be/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f15b3b91-4b55-4389-8caa-8b4beb38c4be",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=208",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f15b3b91-4b55-4389-8caa-8b4beb38c4be",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f15b3b91-4b55-4389-8caa-8b4beb38c4be/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f15b3b91-4b55-4389-8caa-8b4beb38c4be",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c208"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/208",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c209",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7b08104f-8e88-492c-9a8a-b8b356f484fb/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7b08104f-8e88-492c-9a8a-b8b356f484fb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 770,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=209",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3889,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7b08104f-8e88-492c-9a8a-b8b356f484fb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7b08104f-8e88-492c-9a8a-b8b356f484fb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7b08104f-8e88-492c-9a8a-b8b356f484fb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c209"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/209",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c210",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2104ca07-bc9e-4a21-ad22-f9c00fbe1efa/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2104ca07-bc9e-4a21-ad22-f9c00fbe1efa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 761,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 761,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=210",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3862,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2104ca07-bc9e-4a21-ad22-f9c00fbe1efa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2104ca07-bc9e-4a21-ad22-f9c00fbe1efa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 761,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2104ca07-bc9e-4a21-ad22-f9c00fbe1efa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c210"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/210",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c211",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/911648e4-504c-42ab-afcc-dfc11851b5cd/full/80,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/911648e4-504c-42ab-afcc-dfc11851b5cd",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 822,
+              "sizes": [
+                {
+                  "width": 80,
+                  "height": 100
+                },
+                {
+                  "width": 161,
+                  "height": 200
+                },
+                {
+                  "width": 321,
+                  "height": 400
+                },
+                {
+                  "width": 822,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=211",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3060,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/911648e4-504c-42ab-afcc-dfc11851b5cd",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/911648e4-504c-42ab-afcc-dfc11851b5cd/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 822,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/911648e4-504c-42ab-afcc-dfc11851b5cd",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c211"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/211",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c212",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0abdb1ed-0b4f-4c23-972d-e5890bc66b06/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0abdb1ed-0b4f-4c23-972d-e5890bc66b06",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=212",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0abdb1ed-0b4f-4c23-972d-e5890bc66b06",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0abdb1ed-0b4f-4c23-972d-e5890bc66b06/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0abdb1ed-0b4f-4c23-972d-e5890bc66b06",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c212"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/212",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c213",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fa8cc4b0-1a65-41db-a147-29066da94dea/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fa8cc4b0-1a65-41db-a147-29066da94dea",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=213",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fa8cc4b0-1a65-41db-a147-29066da94dea",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fa8cc4b0-1a65-41db-a147-29066da94dea/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fa8cc4b0-1a65-41db-a147-29066da94dea",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c213"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/213",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c214",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9643de2b-51a3-47d0-a2af-cd7edfac4a36/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9643de2b-51a3-47d0-a2af-cd7edfac4a36",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=214",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3802,
+          "width": 2855,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9643de2b-51a3-47d0-a2af-cd7edfac4a36",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9643de2b-51a3-47d0-a2af-cd7edfac4a36/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9643de2b-51a3-47d0-a2af-cd7edfac4a36",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c214"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/214",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c215",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1f46adfe-8445-404e-aa2d-79257fbc591e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1f46adfe-8445-404e-aa2d-79257fbc591e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=215",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1f46adfe-8445-404e-aa2d-79257fbc591e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1f46adfe-8445-404e-aa2d-79257fbc591e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1f46adfe-8445-404e-aa2d-79257fbc591e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c215"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/215",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c216",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e67b692f-3bd3-4e9d-b70b-cd3656e6f13d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e67b692f-3bd3-4e9d-b70b-cd3656e6f13d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=216",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e67b692f-3bd3-4e9d-b70b-cd3656e6f13d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e67b692f-3bd3-4e9d-b70b-cd3656e6f13d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e67b692f-3bd3-4e9d-b70b-cd3656e6f13d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c216"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/216",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c217",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7dae52c6-1b7c-4d58-be77-f0350ccd4beb/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7dae52c6-1b7c-4d58-be77-f0350ccd4beb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=217",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7dae52c6-1b7c-4d58-be77-f0350ccd4beb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7dae52c6-1b7c-4d58-be77-f0350ccd4beb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7dae52c6-1b7c-4d58-be77-f0350ccd4beb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c217"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/217",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c218",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d867698a-1370-429c-a0a8-188ff8105409/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d867698a-1370-429c-a0a8-188ff8105409",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=218",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3830,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d867698a-1370-429c-a0a8-188ff8105409",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d867698a-1370-429c-a0a8-188ff8105409/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d867698a-1370-429c-a0a8-188ff8105409",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c218"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/218",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c219",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7601e1f7-2496-402f-9f08-6a5725b104dd/full/80,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7601e1f7-2496-402f-9f08-6a5725b104dd",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 819,
+              "sizes": [
+                {
+                  "width": 80,
+                  "height": 100
+                },
+                {
+                  "width": 160,
+                  "height": 200
+                },
+                {
+                  "width": 320,
+                  "height": 400
+                },
+                {
+                  "width": 819,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=219",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3049,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7601e1f7-2496-402f-9f08-6a5725b104dd",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7601e1f7-2496-402f-9f08-6a5725b104dd/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 819,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7601e1f7-2496-402f-9f08-6a5725b104dd",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c219"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/219",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c220",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4685e736-4163-41c0-9799-abee4854f243/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4685e736-4163-41c0-9799-abee4854f243",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=220",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4685e736-4163-41c0-9799-abee4854f243",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4685e736-4163-41c0-9799-abee4854f243/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4685e736-4163-41c0-9799-abee4854f243",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c220"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/220",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c221",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8c290b67-e2f8-47cb-924e-6f36440a5d74/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8c290b67-e2f8-47cb-924e-6f36440a5d74",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 781,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 781,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=221",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3845,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8c290b67-e2f8-47cb-924e-6f36440a5d74",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8c290b67-e2f8-47cb-924e-6f36440a5d74/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 781,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8c290b67-e2f8-47cb-924e-6f36440a5d74",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c221"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/221",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c222",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fc8bceef-4b75-4d96-8942-12b0e729cdc9/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fc8bceef-4b75-4d96-8942-12b0e729cdc9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=222",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3856,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/fc8bceef-4b75-4d96-8942-12b0e729cdc9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fc8bceef-4b75-4d96-8942-12b0e729cdc9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fc8bceef-4b75-4d96-8942-12b0e729cdc9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c222"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/222",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c223",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ab82907e-ff2d-4d36-8bc5-3cc08c615624/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ab82907e-ff2d-4d36-8bc5-3cc08c615624",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=223",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ab82907e-ff2d-4d36-8bc5-3cc08c615624",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ab82907e-ff2d-4d36-8bc5-3cc08c615624/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ab82907e-ff2d-4d36-8bc5-3cc08c615624",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c223"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/223",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c224",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6f3f6548-798d-48d7-98e6-575ec4e0049c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6f3f6548-798d-48d7-98e6-575ec4e0049c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=224",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/6f3f6548-798d-48d7-98e6-575ec4e0049c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6f3f6548-798d-48d7-98e6-575ec4e0049c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6f3f6548-798d-48d7-98e6-575ec4e0049c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c224"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/224",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c225",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9f79ef70-ada4-4831-84a7-08c3588c9818/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9f79ef70-ada4-4831-84a7-08c3588c9818",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=225",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9f79ef70-ada4-4831-84a7-08c3588c9818",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9f79ef70-ada4-4831-84a7-08c3588c9818/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9f79ef70-ada4-4831-84a7-08c3588c9818",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c225"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/225",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c226",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d0f6315c-ede5-4d3a-b596-02b4297aa185/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d0f6315c-ede5-4d3a-b596-02b4297aa185",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 766,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=226",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3796,
+          "width": 2839,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d0f6315c-ede5-4d3a-b596-02b4297aa185",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d0f6315c-ede5-4d3a-b596-02b4297aa185/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d0f6315c-ede5-4d3a-b596-02b4297aa185",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c226"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/226",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c227",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/915e1fe4-b404-422f-a5e3-1c865df55e3f/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/915e1fe4-b404-422f-a5e3-1c865df55e3f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 808,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 316,
+                  "height": 400
+                },
+                {
+                  "width": 808,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=227",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3009,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/915e1fe4-b404-422f-a5e3-1c865df55e3f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/915e1fe4-b404-422f-a5e3-1c865df55e3f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 808,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/915e1fe4-b404-422f-a5e3-1c865df55e3f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c227"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/227",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c228",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/804b3da2-dd18-45a0-9c35-3d4056367d3f/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/804b3da2-dd18-45a0-9c35-3d4056367d3f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=228",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/804b3da2-dd18-45a0-9c35-3d4056367d3f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/804b3da2-dd18-45a0-9c35-3d4056367d3f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/804b3da2-dd18-45a0-9c35-3d4056367d3f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c228"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/228",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c229",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/42050f62-1ae7-4051-977b-56afecb5c61d/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/42050f62-1ae7-4051-977b-56afecb5c61d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 755,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=229",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3935,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/42050f62-1ae7-4051-977b-56afecb5c61d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/42050f62-1ae7-4051-977b-56afecb5c61d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/42050f62-1ae7-4051-977b-56afecb5c61d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c229"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/229",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c230",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/11065399-6726-4361-bd76-5003ff9c7df8/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/11065399-6726-4361-bd76-5003ff9c7df8",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=230",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3835,
+          "width": 2878,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/11065399-6726-4361-bd76-5003ff9c7df8",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/11065399-6726-4361-bd76-5003ff9c7df8/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/11065399-6726-4361-bd76-5003ff9c7df8",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c230"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/230",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c231",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d08402da-47c7-468e-af6d-aa0c6e03fb7a/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d08402da-47c7-468e-af6d-aa0c6e03fb7a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 807,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 315,
+                  "height": 400
+                },
+                {
+                  "width": 807,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=231",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3004,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d08402da-47c7-468e-af6d-aa0c6e03fb7a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d08402da-47c7-468e-af6d-aa0c6e03fb7a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 807,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d08402da-47c7-468e-af6d-aa0c6e03fb7a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c231"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/231",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c232",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/192b0365-6ce7-4d42-9606-b0f33e293821/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/192b0365-6ce7-4d42-9606-b0f33e293821",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=232",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3809,
+          "width": 2855,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/192b0365-6ce7-4d42-9606-b0f33e293821",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/192b0365-6ce7-4d42-9606-b0f33e293821/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/192b0365-6ce7-4d42-9606-b0f33e293821",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c232"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/232",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c233",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ece1bbd4-9157-4a4e-9c5c-a224968cc754/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ece1bbd4-9157-4a4e-9c5c-a224968cc754",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=233",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ece1bbd4-9157-4a4e-9c5c-a224968cc754",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ece1bbd4-9157-4a4e-9c5c-a224968cc754/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ece1bbd4-9157-4a4e-9c5c-a224968cc754",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c233"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/233",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c234",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/52b7e0c9-5e3d-423c-ad7e-7aa490ba08fe/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/52b7e0c9-5e3d-423c-ad7e-7aa490ba08fe",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 752,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 752,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=234",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3901,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/52b7e0c9-5e3d-423c-ad7e-7aa490ba08fe",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/52b7e0c9-5e3d-423c-ad7e-7aa490ba08fe/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 752,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/52b7e0c9-5e3d-423c-ad7e-7aa490ba08fe",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c234"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/234",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c235",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/dc7b2ad9-87cb-404b-8467-02543e2efed5/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/dc7b2ad9-87cb-404b-8467-02543e2efed5",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=235",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/dc7b2ad9-87cb-404b-8467-02543e2efed5",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/dc7b2ad9-87cb-404b-8467-02543e2efed5/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dc7b2ad9-87cb-404b-8467-02543e2efed5",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c235"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/235",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c236",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/81b1ab8e-e84c-4987-889c-40c3c2af3658/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/81b1ab8e-e84c-4987-889c-40c3c2af3658",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=236",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/81b1ab8e-e84c-4987-889c-40c3c2af3658",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/81b1ab8e-e84c-4987-889c-40c3c2af3658/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/81b1ab8e-e84c-4987-889c-40c3c2af3658",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c236"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/236",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c237",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8c023d11-5616-40c6-a6d2-1e0feaf91e4c/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8c023d11-5616-40c6-a6d2-1e0feaf91e4c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=237",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3882,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8c023d11-5616-40c6-a6d2-1e0feaf91e4c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8c023d11-5616-40c6-a6d2-1e0feaf91e4c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8c023d11-5616-40c6-a6d2-1e0feaf91e4c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c237"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/237",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c238",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1747f0d2-d4db-44d4-a3a6-54a52be74494/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1747f0d2-d4db-44d4-a3a6-54a52be74494",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 756,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=238",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3795,
+          "width": 2802,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/1747f0d2-d4db-44d4-a3a6-54a52be74494",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1747f0d2-d4db-44d4-a3a6-54a52be74494/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1747f0d2-d4db-44d4-a3a6-54a52be74494",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c238"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/238",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c239",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/76405ee6-72b5-4003-8337-425660f2a5eb/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/76405ee6-72b5-4003-8337-425660f2a5eb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 767,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=239",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3905,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/76405ee6-72b5-4003-8337-425660f2a5eb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/76405ee6-72b5-4003-8337-425660f2a5eb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/76405ee6-72b5-4003-8337-425660f2a5eb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c239"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/239",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c240",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f79d4469-cd09-4b38-9595-e7d53f44474c/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f79d4469-cd09-4b38-9595-e7d53f44474c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 761,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 761,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=240",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3842,
+          "width": 2855,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f79d4469-cd09-4b38-9595-e7d53f44474c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f79d4469-cd09-4b38-9595-e7d53f44474c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 761,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f79d4469-cd09-4b38-9595-e7d53f44474c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c240"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/240",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c241",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d4ed6478-f715-46f0-a26d-f190597af824/full/83,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d4ed6478-f715-46f0-a26d-f190597af824",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 850,
+              "sizes": [
+                {
+                  "width": 83,
+                  "height": 100
+                },
+                {
+                  "width": 166,
+                  "height": 200
+                },
+                {
+                  "width": 332,
+                  "height": 400
+                },
+                {
+                  "width": 850,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=241",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3166,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d4ed6478-f715-46f0-a26d-f190597af824",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d4ed6478-f715-46f0-a26d-f190597af824/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 850,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d4ed6478-f715-46f0-a26d-f190597af824",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c241"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/241",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c242",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d3a1433f-a02a-4a94-8fca-eed9a5801304/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d3a1433f-a02a-4a94-8fca-eed9a5801304",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=242",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d3a1433f-a02a-4a94-8fca-eed9a5801304",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d3a1433f-a02a-4a94-8fca-eed9a5801304/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d3a1433f-a02a-4a94-8fca-eed9a5801304",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c242"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/242",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c243",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/def3fed2-6f32-4e44-a468-42a61c63197d/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/def3fed2-6f32-4e44-a468-42a61c63197d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 777,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 777,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=243",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3865,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/def3fed2-6f32-4e44-a468-42a61c63197d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/def3fed2-6f32-4e44-a468-42a61c63197d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 777,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/def3fed2-6f32-4e44-a468-42a61c63197d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c243"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/243",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c244",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/eddbaebb-2093-49da-a78d-4fdf54a0f311/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/eddbaebb-2093-49da-a78d-4fdf54a0f311",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 763,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=244",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3842,
+          "width": 2863,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/eddbaebb-2093-49da-a78d-4fdf54a0f311",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/eddbaebb-2093-49da-a78d-4fdf54a0f311/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/eddbaebb-2093-49da-a78d-4fdf54a0f311",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c244"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/244",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c245",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c213b449-f7a6-4ce0-93f9-0035c5294519/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c213b449-f7a6-4ce0-93f9-0035c5294519",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=245",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c213b449-f7a6-4ce0-93f9-0035c5294519",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c213b449-f7a6-4ce0-93f9-0035c5294519/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c213b449-f7a6-4ce0-93f9-0035c5294519",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c245"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/245",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c246",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a5921bd2-0e2f-48f2-8943-9277b6d5bc4c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a5921bd2-0e2f-48f2-8943-9277b6d5bc4c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=246",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a5921bd2-0e2f-48f2-8943-9277b6d5bc4c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a5921bd2-0e2f-48f2-8943-9277b6d5bc4c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a5921bd2-0e2f-48f2-8943-9277b6d5bc4c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c246"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/246",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c247",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/632271ca-64c7-4dc7-95e0-589c70b07712/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/632271ca-64c7-4dc7-95e0-589c70b07712",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=247",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/632271ca-64c7-4dc7-95e0-589c70b07712",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/632271ca-64c7-4dc7-95e0-589c70b07712/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/632271ca-64c7-4dc7-95e0-589c70b07712",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c247"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/247",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c248",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7ded41d7-d092-4055-aa1e-0c6c5fb767c2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7ded41d7-d092-4055-aa1e-0c6c5fb767c2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 765,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=248",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3865,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7ded41d7-d092-4055-aa1e-0c6c5fb767c2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7ded41d7-d092-4055-aa1e-0c6c5fb767c2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7ded41d7-d092-4055-aa1e-0c6c5fb767c2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c248"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/248",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c249",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/228e3cee-7102-467f-9acb-df4548ee54b2/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/228e3cee-7102-467f-9acb-df4548ee54b2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=249",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/228e3cee-7102-467f-9acb-df4548ee54b2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/228e3cee-7102-467f-9acb-df4548ee54b2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/228e3cee-7102-467f-9acb-df4548ee54b2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c249"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/249",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c250",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/dcf52e33-2b5a-4bdc-bb76-efe37c28d7f7/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/dcf52e33-2b5a-4bdc-bb76-efe37c28d7f7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 807,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 315,
+                  "height": 400
+                },
+                {
+                  "width": 807,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=250",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3006,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/dcf52e33-2b5a-4bdc-bb76-efe37c28d7f7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/dcf52e33-2b5a-4bdc-bb76-efe37c28d7f7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 807,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dcf52e33-2b5a-4bdc-bb76-efe37c28d7f7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c250"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/250",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c251",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/26aed2e1-93b4-4261-af55-46c6039cd08d/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/26aed2e1-93b4-4261-af55-46c6039cd08d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=251",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3851,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/26aed2e1-93b4-4261-af55-46c6039cd08d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/26aed2e1-93b4-4261-af55-46c6039cd08d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/26aed2e1-93b4-4261-af55-46c6039cd08d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c251"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/251",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c252",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4734a2d7-a7e7-4800-8811-c033a35d2527/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4734a2d7-a7e7-4800-8811-c033a35d2527",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 770,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=252",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3837,
+          "width": 2886,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4734a2d7-a7e7-4800-8811-c033a35d2527",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4734a2d7-a7e7-4800-8811-c033a35d2527/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4734a2d7-a7e7-4800-8811-c033a35d2527",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c252"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/252",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c253",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0c220a03-e779-472d-8f66-1a8b3f1439d7/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0c220a03-e779-472d-8f66-1a8b3f1439d7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=253",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0c220a03-e779-472d-8f66-1a8b3f1439d7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0c220a03-e779-472d-8f66-1a8b3f1439d7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0c220a03-e779-472d-8f66-1a8b3f1439d7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c253"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/253",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c254",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/af98e198-8124-4ac8-ab76-518d9b3329ba/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/af98e198-8124-4ac8-ab76-518d9b3329ba",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=254",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/af98e198-8124-4ac8-ab76-518d9b3329ba",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/af98e198-8124-4ac8-ab76-518d9b3329ba/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/af98e198-8124-4ac8-ab76-518d9b3329ba",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c254"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/254",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c255",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4fa2ff32-a78b-4698-a4e0-579e3dd1edf9/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4fa2ff32-a78b-4698-a4e0-579e3dd1edf9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 764,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=255",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3888,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4fa2ff32-a78b-4698-a4e0-579e3dd1edf9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4fa2ff32-a78b-4698-a4e0-579e3dd1edf9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4fa2ff32-a78b-4698-a4e0-579e3dd1edf9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c255"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/255",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c256",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d286710a-4c59-440a-b1f1-9e9d585ce179/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d286710a-4c59-440a-b1f1-9e9d585ce179",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 751,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 751,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=256",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3870,
+          "width": 2840,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d286710a-4c59-440a-b1f1-9e9d585ce179",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d286710a-4c59-440a-b1f1-9e9d585ce179/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 751,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d286710a-4c59-440a-b1f1-9e9d585ce179",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c256"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/256",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c257",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c86873a5-36d2-4aa5-9cdb-541012656b07/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c86873a5-36d2-4aa5-9cdb-541012656b07",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=257",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c86873a5-36d2-4aa5-9cdb-541012656b07",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c86873a5-36d2-4aa5-9cdb-541012656b07/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c86873a5-36d2-4aa5-9cdb-541012656b07",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c257"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/257",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c258",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/be9fe454-bb55-408d-a7ef-3058f128fb5d/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/be9fe454-bb55-408d-a7ef-3058f128fb5d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=258",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/be9fe454-bb55-408d-a7ef-3058f128fb5d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/be9fe454-bb55-408d-a7ef-3058f128fb5d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/be9fe454-bb55-408d-a7ef-3058f128fb5d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c258"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/258",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c259",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d635da8d-4141-4f2a-bcac-2356d5dc3905/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d635da8d-4141-4f2a-bcac-2356d5dc3905",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=259",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d635da8d-4141-4f2a-bcac-2356d5dc3905",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d635da8d-4141-4f2a-bcac-2356d5dc3905/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d635da8d-4141-4f2a-bcac-2356d5dc3905",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c259"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/259",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c260",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c8308559-3481-408b-9a68-3315dc2f42d9/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c8308559-3481-408b-9a68-3315dc2f42d9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=260",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3827,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c8308559-3481-408b-9a68-3315dc2f42d9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c8308559-3481-408b-9a68-3315dc2f42d9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c8308559-3481-408b-9a68-3315dc2f42d9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c260"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/260",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c261",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9fb1dd3d-b9d6-4140-8b7c-47c2aad5e4cd/full/81,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9fb1dd3d-b9d6-4140-8b7c-47c2aad5e4cd",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 827,
+              "sizes": [
+                {
+                  "width": 81,
+                  "height": 100
+                },
+                {
+                  "width": 162,
+                  "height": 200
+                },
+                {
+                  "width": 323,
+                  "height": 400
+                },
+                {
+                  "width": 827,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=261",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3079,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9fb1dd3d-b9d6-4140-8b7c-47c2aad5e4cd",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9fb1dd3d-b9d6-4140-8b7c-47c2aad5e4cd/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 827,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9fb1dd3d-b9d6-4140-8b7c-47c2aad5e4cd",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c261"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/261",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c262",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d2e06925-9d24-414a-bd10-ac2ff8c139b2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d2e06925-9d24-414a-bd10-ac2ff8c139b2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 779,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 779,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=262",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3832,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d2e06925-9d24-414a-bd10-ac2ff8c139b2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d2e06925-9d24-414a-bd10-ac2ff8c139b2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 779,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d2e06925-9d24-414a-bd10-ac2ff8c139b2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c262"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/262",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c263",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a6d678b6-9b9e-410f-9ee5-4e9463f67c5b/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a6d678b6-9b9e-410f-9ee5-4e9463f67c5b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 779,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 779,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=263",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3874,
+          "width": 2947,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a6d678b6-9b9e-410f-9ee5-4e9463f67c5b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a6d678b6-9b9e-410f-9ee5-4e9463f67c5b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 779,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a6d678b6-9b9e-410f-9ee5-4e9463f67c5b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c263"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/263",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c264",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/627b79aa-76f7-4400-a81d-a34028780493/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/627b79aa-76f7-4400-a81d-a34028780493",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 763,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=264",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3862,
+          "width": 2878,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/627b79aa-76f7-4400-a81d-a34028780493",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/627b79aa-76f7-4400-a81d-a34028780493/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/627b79aa-76f7-4400-a81d-a34028780493",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c264"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/264",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c265",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4b4bc98d-377b-4a63-bb6e-5a93d57ddba9/full/80,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4b4bc98d-377b-4a63-bb6e-5a93d57ddba9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 815,
+              "sizes": [
+                {
+                  "width": 80,
+                  "height": 100
+                },
+                {
+                  "width": 159,
+                  "height": 200
+                },
+                {
+                  "width": 318,
+                  "height": 400
+                },
+                {
+                  "width": 815,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=265",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3035,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4b4bc98d-377b-4a63-bb6e-5a93d57ddba9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4b4bc98d-377b-4a63-bb6e-5a93d57ddba9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 815,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4b4bc98d-377b-4a63-bb6e-5a93d57ddba9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c265"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/265",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c266",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/f9bafe61-a905-4661-8743-a369d051717b/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/f9bafe61-a905-4661-8743-a369d051717b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 782,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 782,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=266",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3791,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/f9bafe61-a905-4661-8743-a369d051717b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/f9bafe61-a905-4661-8743-a369d051717b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 782,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f9bafe61-a905-4661-8743-a369d051717b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c266"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/266",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c267",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/60f85b6b-8d44-4042-8ac9-f097a2b840fe/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/60f85b6b-8d44-4042-8ac9-f097a2b840fe",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=267",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3849,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/60f85b6b-8d44-4042-8ac9-f097a2b840fe",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/60f85b6b-8d44-4042-8ac9-f097a2b840fe/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/60f85b6b-8d44-4042-8ac9-f097a2b840fe",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c267"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/267",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c268",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5206f3df-96bb-4231-bb90-6265d1b556de/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5206f3df-96bb-4231-bb90-6265d1b556de",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 761,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 761,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=268",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3843,
+          "width": 2855,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/5206f3df-96bb-4231-bb90-6265d1b556de",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5206f3df-96bb-4231-bb90-6265d1b556de/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 761,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5206f3df-96bb-4231-bb90-6265d1b556de",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c268"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/268",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c269",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e88bf78d-b10e-415a-a385-3746e14b94d4/full/80,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e88bf78d-b10e-415a-a385-3746e14b94d4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 823,
+              "sizes": [
+                {
+                  "width": 80,
+                  "height": 100
+                },
+                {
+                  "width": 161,
+                  "height": 200
+                },
+                {
+                  "width": 322,
+                  "height": 400
+                },
+                {
+                  "width": 823,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=269",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 3065,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e88bf78d-b10e-415a-a385-3746e14b94d4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e88bf78d-b10e-415a-a385-3746e14b94d4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 823,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e88bf78d-b10e-415a-a385-3746e14b94d4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c269"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/269",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c270",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a8e3d0c2-fdde-4419-b03f-e12877a83265/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a8e3d0c2-fdde-4419-b03f-e12877a83265",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 767,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=270",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3833,
+          "width": 2871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a8e3d0c2-fdde-4419-b03f-e12877a83265",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a8e3d0c2-fdde-4419-b03f-e12877a83265/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a8e3d0c2-fdde-4419-b03f-e12877a83265",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c270"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/270",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c271",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7df5b502-7ed8-4d84-9cce-828ec4ba5575/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7df5b502-7ed8-4d84-9cce-828ec4ba5575",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 773,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=271",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7df5b502-7ed8-4d84-9cce-828ec4ba5575",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7df5b502-7ed8-4d84-9cce-828ec4ba5575/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7df5b502-7ed8-4d84-9cce-828ec4ba5575",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c271"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/271",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c272",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/115c0bd0-3d0e-4937-9396-d08ad8b5464a/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/115c0bd0-3d0e-4937-9396-d08ad8b5464a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 769,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=272",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3875,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/115c0bd0-3d0e-4937-9396-d08ad8b5464a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/115c0bd0-3d0e-4937-9396-d08ad8b5464a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/115c0bd0-3d0e-4937-9396-d08ad8b5464a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c272"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/272",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c273",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/49085776-8c96-4cd2-a808-bd7e89489848/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/49085776-8c96-4cd2-a808-bd7e89489848",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=273",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/49085776-8c96-4cd2-a808-bd7e89489848",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/49085776-8c96-4cd2-a808-bd7e89489848/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/49085776-8c96-4cd2-a808-bd7e89489848",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c273"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/273",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c274",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/12603778-8cfb-49f7-9627-9433ce8c2aa7/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/12603778-8cfb-49f7-9627-9433ce8c2aa7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 784,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 306,
+                  "height": 400
+                },
+                {
+                  "width": 784,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=274",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3848,
+          "width": 2947,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/12603778-8cfb-49f7-9627-9433ce8c2aa7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/12603778-8cfb-49f7-9627-9433ce8c2aa7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/12603778-8cfb-49f7-9627-9433ce8c2aa7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c274"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/274",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c275",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0b5e6583-0532-4f0c-9993-889bddd0ad26/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0b5e6583-0532-4f0c-9993-889bddd0ad26",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=275",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3874,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0b5e6583-0532-4f0c-9993-889bddd0ad26",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0b5e6583-0532-4f0c-9993-889bddd0ad26/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0b5e6583-0532-4f0c-9993-889bddd0ad26",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c275"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/275",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c276",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cbe60cf1-9106-4018-a31f-f775c2f6b120/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cbe60cf1-9106-4018-a31f-f775c2f6b120",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 781,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 781,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=276",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3844,
+          "width": 2931,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/cbe60cf1-9106-4018-a31f-f775c2f6b120",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cbe60cf1-9106-4018-a31f-f775c2f6b120/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 781,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cbe60cf1-9106-4018-a31f-f775c2f6b120",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c276"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/276",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c277",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/00b64654-2090-412c-a2c8-5dc9d7863821/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/00b64654-2090-412c-a2c8-5dc9d7863821",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=277",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/00b64654-2090-412c-a2c8-5dc9d7863821",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/00b64654-2090-412c-a2c8-5dc9d7863821/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/00b64654-2090-412c-a2c8-5dc9d7863821",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c277"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/277",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c278",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4ea3f4a5-823e-4326-abd7-da0d4f29596b/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4ea3f4a5-823e-4326-abd7-da0d4f29596b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 781,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 305,
+                  "height": 400
+                },
+                {
+                  "width": 781,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=278",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/4ea3f4a5-823e-4326-abd7-da0d4f29596b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4ea3f4a5-823e-4326-abd7-da0d4f29596b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 781,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4ea3f4a5-823e-4326-abd7-da0d4f29596b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c278"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/278",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c279",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/379b98af-14dc-47e6-9fc9-855845a3fefc/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/379b98af-14dc-47e6-9fc9-855845a3fefc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=279",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3869,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/379b98af-14dc-47e6-9fc9-855845a3fefc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/379b98af-14dc-47e6-9fc9-855845a3fefc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/379b98af-14dc-47e6-9fc9-855845a3fefc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c279"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/279",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c280",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/99bc36e4-557c-42be-8c2b-eedf6c3634db/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/99bc36e4-557c-42be-8c2b-eedf6c3634db",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 771,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=280",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3845,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/99bc36e4-557c-42be-8c2b-eedf6c3634db",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/99bc36e4-557c-42be-8c2b-eedf6c3634db/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/99bc36e4-557c-42be-8c2b-eedf6c3634db",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c280"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/280",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c281",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/836e9e5e-7974-4be0-8bcc-bef141f97f6b/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/836e9e5e-7974-4be0-8bcc-bef141f97f6b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=281",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/836e9e5e-7974-4be0-8bcc-bef141f97f6b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/836e9e5e-7974-4be0-8bcc-bef141f97f6b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/836e9e5e-7974-4be0-8bcc-bef141f97f6b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c281"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/281",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c282",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/002bbd2d-1aea-4fa5-93f9-47ff383634fa/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/002bbd2d-1aea-4fa5-93f9-47ff383634fa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 774,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=282",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3839,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/002bbd2d-1aea-4fa5-93f9-47ff383634fa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/002bbd2d-1aea-4fa5-93f9-47ff383634fa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/002bbd2d-1aea-4fa5-93f9-47ff383634fa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c282"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/282",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c283",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/01a3f491-ee03-42db-a22a-bb5a42b041d1/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/01a3f491-ee03-42db-a22a-bb5a42b041d1",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 761,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 761,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=283",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3912,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/01a3f491-ee03-42db-a22a-bb5a42b041d1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/01a3f491-ee03-42db-a22a-bb5a42b041d1/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 761,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/01a3f491-ee03-42db-a22a-bb5a42b041d1",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c283"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/283",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c284",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7124d429-b003-4723-96a7-878472d86f29/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7124d429-b003-4723-96a7-878472d86f29",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=284",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3877,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/7124d429-b003-4723-96a7-878472d86f29",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7124d429-b003-4723-96a7-878472d86f29/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7124d429-b003-4723-96a7-878472d86f29",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c284"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/284",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c285",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/29fc6c3e-f729-40c0-9dd6-1681c3015c8c/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/29fc6c3e-f729-40c0-9dd6-1681c3015c8c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=285",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/29fc6c3e-f729-40c0-9dd6-1681c3015c8c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/29fc6c3e-f729-40c0-9dd6-1681c3015c8c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/29fc6c3e-f729-40c0-9dd6-1681c3015c8c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c285"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/285",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c286",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/48d07b14-029d-4911-b45d-e19260575232/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/48d07b14-029d-4911-b45d-e19260575232",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 786,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 786,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=286",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3808,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/48d07b14-029d-4911-b45d-e19260575232",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/48d07b14-029d-4911-b45d-e19260575232/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 786,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/48d07b14-029d-4911-b45d-e19260575232",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c286"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/286",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c287",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/596c95c9-79cf-4250-ae8e-f451022aedfb/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/596c95c9-79cf-4250-ae8e-f451022aedfb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 773,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=287",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3866,
+          "width": 2917,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/596c95c9-79cf-4250-ae8e-f451022aedfb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/596c95c9-79cf-4250-ae8e-f451022aedfb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/596c95c9-79cf-4250-ae8e-f451022aedfb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c287"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/287",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c288",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9942845c-453e-4525-a374-2879cb8cb27e/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9942845c-453e-4525-a374-2879cb8cb27e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 772,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=288",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3847,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/9942845c-453e-4525-a374-2879cb8cb27e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9942845c-453e-4525-a374-2879cb8cb27e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9942845c-453e-4525-a374-2879cb8cb27e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c288"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/288",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c289",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/41c401e1-d5d2-49dd-a7e0-9e19232fee8e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/41c401e1-d5d2-49dd-a7e0-9e19232fee8e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=289",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/41c401e1-d5d2-49dd-a7e0-9e19232fee8e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/41c401e1-d5d2-49dd-a7e0-9e19232fee8e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/41c401e1-d5d2-49dd-a7e0-9e19232fee8e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c289"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/289",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c290",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/a68ce4e6-94d1-45ce-914a-9ae0957ac1d4/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/a68ce4e6-94d1-45ce-914a-9ae0957ac1d4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=290",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3825,
+          "width": 2894,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/a68ce4e6-94d1-45ce-914a-9ae0957ac1d4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/a68ce4e6-94d1-45ce-914a-9ae0957ac1d4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a68ce4e6-94d1-45ce-914a-9ae0957ac1d4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c290"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/290",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c291",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ebfc8272-bb76-4d76-98a4-d352118370d4/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ebfc8272-bb76-4d76-98a4-d352118370d4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=291",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3879,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/ebfc8272-bb76-4d76-98a4-d352118370d4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ebfc8272-bb76-4d76-98a4-d352118370d4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ebfc8272-bb76-4d76-98a4-d352118370d4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c291"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/291",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c292",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/abcf406c-0859-4df3-87a0-de3715b314ec/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/abcf406c-0859-4df3-87a0-de3715b314ec",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 768,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=292",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3867,
+          "width": 2901,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/abcf406c-0859-4df3-87a0-de3715b314ec",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/abcf406c-0859-4df3-87a0-de3715b314ec/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/abcf406c-0859-4df3-87a0-de3715b314ec",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c292"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/292",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c293",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c39b00c9-f364-4538-b642-bf6dd5f9c5aa/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c39b00c9-f364-4538-b642-bf6dd5f9c5aa",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=293",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/c39b00c9-f364-4538-b642-bf6dd5f9c5aa",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c39b00c9-f364-4538-b642-bf6dd5f9c5aa/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c39b00c9-f364-4538-b642-bf6dd5f9c5aa",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c293"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/293",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c294",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e22897c7-8b7b-4c24-9c7c-5e22ee8a5650/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e22897c7-8b7b-4c24-9c7c-5e22ee8a5650",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 779,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 779,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=294",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3826,
+          "width": 2909,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e22897c7-8b7b-4c24-9c7c-5e22ee8a5650",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e22897c7-8b7b-4c24-9c7c-5e22ee8a5650/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 779,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e22897c7-8b7b-4c24-9c7c-5e22ee8a5650",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c294"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/294",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c295",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/454faab7-68dd-48f1-8ddb-cb386704bdec/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/454faab7-68dd-48f1-8ddb-cb386704bdec",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 778,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 778,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=295",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3870,
+          "width": 2939,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/454faab7-68dd-48f1-8ddb-cb386704bdec",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/454faab7-68dd-48f1-8ddb-cb386704bdec/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 778,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/454faab7-68dd-48f1-8ddb-cb386704bdec",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c295"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/295",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c296",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0049b5ad-6140-4c62-8eae-564393b499d9/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0049b5ad-6140-4c62-8eae-564393b499d9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 754,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=296",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3839,
+          "width": 2825,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0049b5ad-6140-4c62-8eae-564393b499d9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0049b5ad-6140-4c62-8eae-564393b499d9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0049b5ad-6140-4c62-8eae-564393b499d9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c296"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/296",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c297",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/310ff80e-2d1f-4739-8abd-baf3d00d95ab/full/78,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/310ff80e-2d1f-4739-8abd-baf3d00d95ab",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 801,
+              "sizes": [
+                {
+                  "width": 78,
+                  "height": 100
+                },
+                {
+                  "width": 156,
+                  "height": 200
+                },
+                {
+                  "width": 313,
+                  "height": 400
+                },
+                {
+                  "width": 801,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=297",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3740,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/310ff80e-2d1f-4739-8abd-baf3d00d95ab",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/310ff80e-2d1f-4739-8abd-baf3d00d95ab/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 801,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/310ff80e-2d1f-4739-8abd-baf3d00d95ab",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c297"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/297",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c298",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8e8a0761-8450-4708-ae3d-643a1c94860e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8e8a0761-8450-4708-ae3d-643a1c94860e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=298",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/8e8a0761-8450-4708-ae3d-643a1c94860e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8e8a0761-8450-4708-ae3d-643a1c94860e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8e8a0761-8450-4708-ae3d-643a1c94860e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c298"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/298",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c299",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0b18f2de-8d16-43ee-b132-501871766523/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0b18f2de-8d16-43ee-b132-501871766523",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=299",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/0b18f2de-8d16-43ee-b132-501871766523",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0b18f2de-8d16-43ee-b132-501871766523/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0b18f2de-8d16-43ee-b132-501871766523",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c299"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/299",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c300",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2181e0b9-f0a0-497e-a8d7-16eccd0a22a2/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2181e0b9-f0a0-497e-a8d7-16eccd0a22a2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=300",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2181e0b9-f0a0-497e-a8d7-16eccd0a22a2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2181e0b9-f0a0-497e-a8d7-16eccd0a22a2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2181e0b9-f0a0-497e-a8d7-16eccd0a22a2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c300"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/300",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c301",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/e09096dc-e5db-44ee-8f11-9dbcdfc43d1e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/e09096dc-e5db-44ee-8f11-9dbcdfc43d1e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=301",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/e09096dc-e5db-44ee-8f11-9dbcdfc43d1e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/e09096dc-e5db-44ee-8f11-9dbcdfc43d1e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e09096dc-e5db-44ee-8f11-9dbcdfc43d1e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c301"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/301",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c302",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/2bde7488-f64d-4a2b-885c-bb56af837a7e/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/2bde7488-f64d-4a2b-885c-bb56af837a7e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 785,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 153,
+                  "height": 200
+                },
+                {
+                  "width": 307,
+                  "height": 400
+                },
+                {
+                  "width": 785,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=302",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3813,
+          "width": 2924,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/2bde7488-f64d-4a2b-885c-bb56af837a7e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/2bde7488-f64d-4a2b-885c-bb56af837a7e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 785,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2bde7488-f64d-4a2b-885c-bb56af837a7e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c302"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/302",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b29353427/canvas/c303",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d72f0457-2dfc-4c2c-94f0-dc8bf35653d1/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d72f0457-2dfc-4c2c-94f0-dc8bf35653d1",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 809,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 316,
+                  "height": 400
+                },
+                {
+                  "width": 809,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "seeAlso": {
+            "@id": "https://wellcomelibrary.org/service/alto/b29353427/0?image=303",
+            "format": "text/xml",
+            "profile": "http://www.loc.gov/standards/alto/v3/alto.xsd",
+            "label": "METS-ALTO XML"
+          },
+          "height": 3740,
+          "width": 2956,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/imageanno/d72f0457-2dfc-4c2c-94f0-dc8bf35653d1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d72f0457-2dfc-4c2c-94f0-dc8bf35653d1/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 809,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d72f0457-2dfc-4c2c-94f0-dc8bf35653d1",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b29353427/canvas/c303"
+            }
+          ],
+          "otherContent": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b29353427/contentAsText/303",
+              "@type": "sc:AnnotationList",
+              "label": "Text of this page"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29353427/range/r-0",
+      "@type": "sc:Range",
+      "label": "Cover",
+      "canvases": [
+        "https://wellcomelibrary.org/iiif/b29353427/canvas/c0"
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29353427/range/r-1",
+      "@type": "sc:Range",
+      "label": "Title Page",
+      "canvases": [
+        "https://wellcomelibrary.org/iiif/b29353427/canvas/c6"
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29353427/range/r-2",
+      "@type": "sc:Range",
+      "label": "Cover",
+      "canvases": [
+        "https://wellcomelibrary.org/iiif/b29353427/canvas/c303"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/4a081ce150ca13d90222747ac7b7579a
+++ b/tests/fixtures/http/4a081ce150ca13d90222747ac7b7579a
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b14601308/manifest",
+  "@type": "sc:Manifest",
+  "label": "An itinerant doctor, by a subterfuge, cures an undergraduate hoaxer of his supposed maladies of lying and bad memory. Coloured etching by T. Rowlandson, 1807, after G.M. Woodward.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "An itinerant doctor, by a subterfuge, cures an undergraduate hoaxer of his supposed maladies of lying and bad memory. Coloured etching by T. Rowlandson, 1807, after G.M. Woodward."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M; Rowlandson, Thomas"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1460130'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b14601308",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b14601308.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b14601308",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b14601308",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b14601308-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b14601308",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b14601308, Digicode: digprojectx, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b14601308/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b14601308/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b14601308/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b/full/78,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 794,
+              "sizes": [
+                {
+                  "width": 78,
+                  "height": 100
+                },
+                {
+                  "width": 155,
+                  "height": 200
+                },
+                {
+                  "width": 310,
+                  "height": 400
+                },
+                {
+                  "width": 794,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3828,
+          "width": 2970,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b14601308/imageanno/59ffd0d4-e103-45ba-8aff-dd524427490b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 794,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b14601308/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/4daeaf167836c9b42a0c1f3d645bfee8
+++ b/tests/fixtures/http/4daeaf167836c9b42a0c1f3d645bfee8
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11603458/manifest",
+  "@type": "sc:Manifest",
+  "label": "William Pitt the younger and his ministers as anatomists dissecting the body of the Prince of Wales; representing Pitt's reduction of the powers of the regent. Coloured etching by Thomas Rowlandson, 1788/1789.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "William Pitt the younger and his ministers as anatomists dissecting the body of the Prince of Wales; representing Pitt's reduction of the powers of the regent. Coloured etching by Thomas Rowlandson, 1788/1789."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Rowlandson, Thomas"
+    },
+    {
+      "label": "Description",
+      "value": "In November 1788 King George III experienced a bout of mental illness, and the Government, under William Pitt the Younger, had to make arrangements for the Prince of Wales to rule as regent. The problem for Pitt was that the Prince of Wales was an ally of Pitt's opponent Charles James Fox. Pitt set up committees to scrutinize the medical reports on the king, and after some delay produced a Regency Bill with reduced powers for the Regent. The print shows Pitt and his colleagues as anatomists cutting the Prince of Wales down to size and extracting his heart in order to make him less popular as regent. The six Ministry members shown are (left to right) Richmond, Grafton, Pitt, Townshend, Dundas, and Thurlow. Pitt sits on the red and gold seat in the centre directing the dissection.  The Lord Chancellor Lord Thurlow, shown in black on the right, was secretly negotiating with Fox to retain the Chancellorship when the Prince of Wales took over. In the end the King recovered his health in February 1789, and the regency was postponed\n\nPitt says to Dundas: \"The good qualities of his heart will certainly ruin our plan therefore cut that out first.\", holding out a paper which reads: \"Thanks from the City of London with £50000\""
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1160345'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11603458",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11603458.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11603458",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11603458",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11603458-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11603458",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11603458, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11603458/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11603458/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11603458/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95/full/100,73/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95",
+              "protocol": "http://iiif.io/api/image",
+              "height": 749,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 73
+                },
+                {
+                  "width": 200,
+                  "height": 146
+                },
+                {
+                  "width": 400,
+                  "height": 293
+                },
+                {
+                  "width": 1024,
+                  "height": 749
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2332,
+          "width": 3189,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11603458/imageanno/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 749,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11603458/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/513b1affa662208c67fa77b76caa9ce7
+++ b/tests/fixtures/http/513b1affa662208c67fa77b76caa9ce7
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11944377/manifest",
+  "@type": "sc:Manifest",
+  "label": "Two young men are approached by a prostitute: she is a clothed skeleton holding a made-up mask in front of her face, representing syphilis. Lithograph by J.J. Grandville, 1830.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Two young men are approached by a prostitute: she is a clothed skeleton holding a made-up mask in front of her face, representing syphilis. Lithograph by J.J. Grandville, 1830."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Grandville, J. J; Langlumé, Pierre"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1194437'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11944377",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11944377.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11944377",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11944377",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11944377-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11944377",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11944377, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11944377/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11944377/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11944377/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281",
+              "protocol": "http://iiif.io/api/image",
+              "height": 797,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 156
+                },
+                {
+                  "width": 400,
+                  "height": 311
+                },
+                {
+                  "width": 1024,
+                  "height": 797
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2343,
+          "width": 3011,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11944377/imageanno/1ead647d-03be-48a7-88cc-43debcc75281",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 797,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11944377/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/5e5d19feaafcf8dff978b5ad589de698
+++ b/tests/fixtures/http/5e5d19feaafcf8dff978b5ad589de698
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11784520/manifest",
+  "@type": "sc:Manifest",
+  "label": "Doctor Botherum, an itinerant medicine vendor (perhaps based on Doctor Bossy) selling his wares on stage with the aid of assistants to a raucous crowd. Coloured etching by T. Rowlandson, 1800.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Doctor Botherum, an itinerant medicine vendor (perhaps based on Doctor Bossy) selling his wares on stage with the aid of assistants to a raucous crowd. Coloured etching by T. Rowlandson, 1800."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Rowlandson, Thomas"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1178452'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11784520",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11784520.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11784520",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11784520",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11784520-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11784520",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11784520, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11784520/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11784520/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11784520/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87/full/100,88/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87",
+              "protocol": "http://iiif.io/api/image",
+              "height": 901,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 88
+                },
+                {
+                  "width": 200,
+                  "height": 176
+                },
+                {
+                  "width": 400,
+                  "height": 352
+                },
+                {
+                  "width": 1024,
+                  "height": 901
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2640,
+          "width": 3000,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11784520/imageanno/bc4c3ebb-68bc-471d-8813-d36291024c87",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 901,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11784520/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/62a635d18084d7abc30c7e067cc92b36
+++ b/tests/fixtures/http/62a635d18084d7abc30c7e067cc92b36
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11957347/manifest",
+  "@type": "sc:Manifest",
+  "label": "A hooded alchemist at a furnace; above him hang dead animals: caricature. Watercolour painting.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A hooded alchemist at a furnace; above him hang dead animals: caricature. Watercolour painting."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1195734'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11957347",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11957347.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11957347",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11957347",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11957347-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11957347",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11957347, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11957347/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11957347/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11957347/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 697,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 697,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7672,
+          "width": 5221,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11957347/imageanno/781fa833-7851-4a19-bd0f-84436898a089",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 697,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11957347/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/65f92c766386698ceb862b58e18f9d0c
+++ b/tests/fixtures/http/65f92c766386698ceb862b58e18f9d0c
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11759021/manifest",
+  "@type": "sc:Manifest",
+  "label": "A family threatened by influenza is prepared for a large scale bloodletting. Coloured etching, 18--.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A family threatened by influenza is prepared for a large scale bloodletting. Coloured etching, 18--."
+    },
+    {
+      "label": "Description",
+      "value": "The surgeon (seated near the centre, with a black jacket and a plum-coloured waistcoat) who has been called in to let blood is addressing the physician (standing wearing a dark blue coat on the left), asking him \"Doctor, how much blood?\". The doctor replies, absurdly, \"Eight units (ròtola) for the whole family: divide yourselves up!\". Ròtola are a unit of weight used in Naples, Palermo and Genoa before the introduction of decimal measures, equivalent to between 0.79 and 0.89 kg or in Malta 0.19 kg (Grande dizionario della lingua italiana, Turin 1970-, vol. XVII, p. 137). Death is pictured on a black backdrop behind the bedbound woman; it is flanked by two paintings of nudes beside the bed. The words \"son morto\" (I'm dead) escape from the mouth of the brown coated man at the far right\n\nComment: In traditional Western medicine diseases are classified according to their symptoms. One important symptom was fever: there were many kinds of fever, and the one which included the symptoms of what was later called in English influenza was epidemic catarrhal fever. In catarrhal fever, the body was struggling to get rid of excessive  fluid (catarrh) and heat (fever, febris). The body could be helped to do this by bloodletting, because reducing an excess of hot and wet blood in the body would reduce the internal heat and fluid. English people started to use the word influenza instead of epidemic catarrhal fever after an epidemic of the disease came to England from Italy in 1743, and English people began to use the Italian colloquial word. This print shows an Italian family of which at least three generations living in the same household are all suffering from influenza or catarrhal fever. The surgeon (seated near the centre, with a black jacket and a plum-coloured waistcoat) who has been called in to let blood is addressing the physician (standing wearing a dark blue coat on the left), asking him \"Doctor, how much blood?\". In this humorous print, the doctor is a careless practitioner, because he replies, absurdly, \"Eight units for the whole family: divide yourselves up!\". A more careful physician would have prescribed more blood for the young and fit adults, and less blood for children and the aged, instead of just giving a total for the family as a whole. There are some practitioners who are careful and precise (even when it does not matter) and some who prescribe carelessly (even when it does matter). The fact that much of health care delivery is a matter of individual personality is one reason why historians have placed little value on the idea of unqualified \"progress\" in medicine"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175902'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11759021",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11759021.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759021",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11759021",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11759021-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11759021",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11759021, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759021/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11759021/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11759021/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6/full/100,70/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6",
+              "protocol": "http://iiif.io/api/image",
+              "height": 717,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 70
+                },
+                {
+                  "width": 200,
+                  "height": 140
+                },
+                {
+                  "width": 400,
+                  "height": 280
+                },
+                {
+                  "width": 1024,
+                  "height": 717
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2234,
+          "width": 3189,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11759021/imageanno/7afd9040-aece-4eb8-b1ea-d611c2cdfef6",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 717,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11759021/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/68d58ac1fa4b1ec4a3f5f477746d9a5b
+++ b/tests/fixtures/http/68d58ac1fa4b1ec4a3f5f477746d9a5b
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b16763269/manifest",
+  "@type": "sc:Manifest",
+  "label": "Cartoon scenes featuring condoms representing a safe sex advertisement by the Folkhälsoinstitutet RFSU och Landstinget Förebygger AIDS. Colour lithograph by L. Nitka, ca. 1995.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Cartoon scenes featuring condoms representing a safe sex advertisement by the Folkhälsoinstitutet RFSU och Landstinget Förebygger AIDS. Colour lithograph by L. Nitka, ca. 1995."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Nitka, Louis; Stockholms län (Sweden)"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1676326'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b16763269",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b16763269.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b16763269",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b16763269",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b16763269-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b16763269",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b16763269, Digicode: digaids, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16763269/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b16763269/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16763269/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 735,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6649,
+          "width": 4771,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16763269/imageanno/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16763269/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/75f922018c514a6b90953764d46f0362
+++ b/tests/fixtures/http/75f922018c514a6b90953764d46f0362
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11743918/manifest",
+  "@type": "sc:Manifest",
+  "label": "A crippled man and a blind man go to court; the lawyer eats oysters and gives them the empty shells. Mezzotint, 1779.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A crippled man and a blind man go to court; the lawyer eats oysters and gives them the empty shells. Mezzotint, 1779."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1174391'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11743918",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11743918.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11743918",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11743918",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11743918-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11743918",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11743918, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11743918/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11743918/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11743918/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 734,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7768,
+          "width": 5565,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11743918/imageanno/20bfd125-4aef-4abe-8924-96cae2dc994e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11743918/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/7a1cfa3928d892630fed34e4181da9be
+++ b/tests/fixtures/http/7a1cfa3928d892630fed34e4181da9be
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b1175820x/manifest",
+  "@type": "sc:Manifest",
+  "label": "A rich miser eating humble food. Coloured etching after G. Piattoli, c. 1800.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A rich miser eating humble food. Coloured etching after G. Piattoli, c. 1800."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Piattoli, Giuseppe"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175820'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b1175820x",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b1175820x.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b1175820x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b1175820x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b1175820x-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b1175820x",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b1175820x, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1175820x/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b1175820x/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b1175820x/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 728,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 728,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7720,
+          "width": 5485,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b1175820x/imageanno/684c6426-5122-4827-8086-34d67b9e0d47",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 728,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b1175820x/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/7d9e65fdef79936ae6376c614de32cee
+++ b/tests/fixtures/http/7d9e65fdef79936ae6376c614de32cee
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b1676321x/manifest",
+  "@type": "sc:Manifest",
+  "label": "A calendar for the year 1994 by Nitka featuring cartoon scenes with condoms; produced by the Folkhälsoinstitutet RFSU [?]. Colour lithograph, ca. 1994.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A calendar for the year 1994 by Nitka featuring cartoon scenes with condoms; produced by the Folkhälsoinstitutet RFSU [?]. Colour lithograph, ca. 1994."
+    },
+    {
+      "label": "Description",
+      "value": "Illustrations include top left: a naked figure standing in a snowy street demanding to borrow a condom from a neighbour; a series of toilets from which arms protrude with symbols featuring the item they require including a towel, a toilet roll and lastly, a condom. Illustrations along bottom include: an Eskimo hanging out a condom to warm over the fire and Santa Claus delivering a box of condoms to the door in which a delighted naked man stands"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1676321'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b1676321x",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b1676321x.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b1676321x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b1676321x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b1676321x-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b1676321x",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b1676321x, Digicode: digaids, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1676321x/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b1676321x/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b1676321x/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 694,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 271,
+                  "height": 400
+                },
+                {
+                  "width": 694,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6622,
+          "width": 4489,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b1676321x/imageanno/60622b55-5548-4f81-90cd-fd886acef5bb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 694,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b1676321x/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/87817c6e8649811cccf18381c247ff3f
+++ b/tests/fixtures/http/87817c6e8649811cccf18381c247ff3f
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11599820/manifest",
+  "@type": "sc:Manifest",
+  "label": "Sixteen feet in profile, of women and men: a parody of phrenology. Coloured etching.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Sixteen feet in profile, of women and men: a parody of phrenology. Coloured etching."
+    },
+    {
+      "label": "Description",
+      "value": "Each of the sixteen feet in the print has a humorous annotation below it in phrenological jargon"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159982'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11599820",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11599820.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11599820",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11599820",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11599820-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11599820",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11599820, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11599820/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11599820/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11599820/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0/full/94,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 966,
+              "sizes": [
+                {
+                  "width": 94,
+                  "height": 100
+                },
+                {
+                  "width": 189,
+                  "height": 200
+                },
+                {
+                  "width": 377,
+                  "height": 400
+                },
+                {
+                  "width": 966,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6478,
+          "width": 6113,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11599820/imageanno/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 966,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11599820/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/8b3c5207380234d77610e1526e05d719
+++ b/tests/fixtures/http/8b3c5207380234d77610e1526e05d719
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11742148/manifest",
+  "@type": "sc:Manifest",
+  "label": "Five antiquaries look through magnifying glasses at objects. Coloured lithograph after L. Boilly, 1823.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Five antiquaries look through magnifying glasses at objects. Coloured lithograph after L. Boilly, 1823."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Boilly, Louis"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1174214'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11742148",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11742148.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11742148",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11742148",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11742148-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11742148",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11742148, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11742148/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11742148/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11742148/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41/full/87,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 894,
+              "sizes": [
+                {
+                  "width": 87,
+                  "height": 100
+                },
+                {
+                  "width": 175,
+                  "height": 200
+                },
+                {
+                  "width": 349,
+                  "height": 400
+                },
+                {
+                  "width": 894,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3036,
+          "width": 2652,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11742148/imageanno/99c39520-ee16-4857-8d7e-60e326f2bd41",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 894,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11742148/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/92715c21973a423b6b433f583e2698e4
+++ b/tests/fixtures/http/92715c21973a423b6b433f583e2698e4
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11589668/manifest",
+  "@type": "sc:Manifest",
+  "label": "A new apothecary's shop open for business, with parody advertisements for different potions; representing the remedies required for different professions and social types. Coloured etching after G.M. Woodward, 1802.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A new apothecary's shop open for business, with parody advertisements for different potions; representing the remedies required for different professions and social types. Coloured etching after G.M. Woodward, 1802."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M"
+    },
+    {
+      "label": "Description",
+      "value": "A humorous allegory showing the requirements of people such as electioneering politicians, gossips, widows, lawyers etc., in the form of a picture of the shop of a Georgian vendor of patent remedies. The forms which the medicines take -- powders, pills, ointments, balsams etc.--are derived from mainstream traditional pharmacy, but the vendor is trying to claim added value by targeting them at the needs of particular groups of customers. In this example of rather laboured Georgian humour, the patent medicines offered are not cures for diseases at all but are cures for specific social situations such as overwork, loneliness, low esteem, networking needs, etc.\n\nThe words: \"Physic for man and horse!! Daniel Drug, dealer in patent medicines\" are above the shop door, \"Kill or cure!!\" on it; the vendor says \"Will nobody buy? -Will nobody buy?\" and his posters display the names of twenty potions for specific types of people. The subject appears to be the low-grade shop of a medicine vendor just starting out in business. Whereas established shops of this period had a panelled doorway with a fanlight above and bow windows to the sides, this one has a stable door, above it is a plain lintel, and at the sides are paper posters stuck on to a wooden framework fixed to the outside wall."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1158966'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11589668",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11589668.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11589668",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11589668",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11589668-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11589668",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11589668, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11589668/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11589668/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11589668/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399",
+              "protocol": "http://iiif.io/api/image",
+              "height": 794,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 310
+                },
+                {
+                  "width": 1024,
+                  "height": 794
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2416,
+          "width": 3116,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11589668/imageanno/9342cb81-1b36-4097-89e6-7d20186b4399",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 794,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11589668/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/955ff083a33681a7b3b100dd31ac67c4
+++ b/tests/fixtures/http/955ff083a33681a7b3b100dd31ac67c4
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b1159987x/manifest",
+  "@type": "sc:Manifest",
+  "label": "A man in bed with vegetables sprouting from all parts of his body; as a result of taking an overdose of James Morison's vegetable pills. Coloured lithograph by C.J. Grant, 1831.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A man in bed with vegetables sprouting from all parts of his body; as a result of taking an overdose of James Morison's vegetable pills. Coloured lithograph by C.J. Grant, 1831."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Grant, C. J"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159987'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b1159987x",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b1159987x.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b1159987x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b1159987x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b1159987x-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b1159987x",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b1159987x, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1159987x/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b1159987x/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b1159987x/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3905,
+          "width": 2955,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b1159987x/imageanno/7f76d636-d450-4096-a1d4-65a2f24db6bc",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b1159987x/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/9783ce32efeb6223c47fab92283c7b7e
+++ b/tests/fixtures/http/9783ce32efeb6223c47fab92283c7b7e
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b16736400/manifest",
+  "@type": "sc:Manifest",
+  "label": "The apparent revival of a dead man by galvanism. Drawing attributed to G.M. Woodward.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "The apparent revival of a dead man by galvanism. Drawing attributed to G.M. Woodward."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M"
+    },
+    {
+      "label": "Description",
+      "value": "Two men express astonishment as a young man sits up from his bed, apparently stimulated by an object tended towards him by a third man. Another man hiding behind the bed pushes the young man upwards with his palm against the young man's back"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1673640'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b16736400",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b16736400.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b16736400",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b16736400",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b16736400-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b16736400",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b16736400, Digicode: n/a, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16736400/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b16736400/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16736400/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 729,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6496,
+          "width": 4625,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16736400/imageanno/8fb54b80-80e6-427d-acd8-6a323f354249",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16736400/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/97c892e908ead14203329f95273317fb
+++ b/tests/fixtures/http/97c892e908ead14203329f95273317fb
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11651222/manifest",
+  "@type": "sc:Manifest",
+  "label": "A figure dressed in a cholera safety suit. Coloured etching after J. Petzl (?), ca. 1832.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A figure dressed in a cholera safety suit. Coloured etching after J. Petzl (?), ca. 1832."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Petzl, Josef; Saphir, Moritz Gottlieb"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1165122'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11651222",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11651222.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11651222",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11651222",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11651222-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11651222",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11651222, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11651222/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11651222/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11651222/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d/full/78,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 801,
+              "sizes": [
+                {
+                  "width": 78,
+                  "height": 100
+                },
+                {
+                  "width": 157,
+                  "height": 200
+                },
+                {
+                  "width": 313,
+                  "height": 400
+                },
+                {
+                  "width": 801,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7296,
+          "width": 5710,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11651222/imageanno/1796f0a8-18c8-4d74-a17b-5f7af0db117d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 801,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11651222/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/9d1c3570ad03e73dad6b4fb11c8c900d
+++ b/tests/fixtures/http/9d1c3570ad03e73dad6b4fb11c8c900d
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11949442/manifest",
+  "@type": "sc:Manifest",
+  "label": "Lord Melbourne and Lord John Russell as schoolboys at a class given by Sir Robert Peel: Lord Brougham peeps from behind a door. Coloured lithograph by H.B. (John Doyle), 1841.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Lord Melbourne and Lord John Russell as schoolboys at a class given by Sir Robert Peel: Lord Brougham peeps from behind a door. Coloured lithograph by H.B. (John Doyle), 1841."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Doyle, John"
+    },
+    {
+      "label": "Description",
+      "value": "The Whig ministry lost a vote of confidence by a majority of one. Parliament was dissolved but on returning the majority was increased by 90 to 91"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1194944'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11949442",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11949442.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11949442",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11949442",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11949442-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11949442",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11949442, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11949442/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11949442/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11949442/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e/full/100,82/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 840,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 82
+                },
+                {
+                  "width": 200,
+                  "height": 164
+                },
+                {
+                  "width": 400,
+                  "height": 328
+                },
+                {
+                  "width": 1024,
+                  "height": 840
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2419,
+          "width": 2950,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11949442/imageanno/9f3d66cc-5282-4b34-bf07-3990acd6a63e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 840,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11949442/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/a5287f58477cbe66e7a023cbeab82e69
+++ b/tests/fixtures/http/a5287f58477cbe66e7a023cbeab82e69
@@ -1,0 +1,1381 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b16804065/manifest",
+  "@type": "sc:Manifest",
+  "label": "Evolution of household articles, animals etc. according to Darwin's doctrine. Colour lithographs by Fr. Schmidt, ca. 187-(?).",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Evolution of household articles, animals etc. according to Darwin's doctrine. Colour lithographs by Fr. Schmidt, ca. 187-(?)."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Schmidt, Fr"
+    },
+    {
+      "label": "Description",
+      "value": "The set of twenty satirical German lithographs about the theory of natural selection recently introduced into Germany through the first translation of Charles Darwin's book The origin of species, which was published in German in 1860. The title leaf recto depicts a hirsute Neanderthal taking leave of his relatives (a pack of tree-climbing monkeys) in pursuit of creatures more like himself. The title leaf verso contains a discussion between two professors of mathematics (A and B) , who have been reduced to geometrical configurations which they study: this takes its departure from a caricature which appears between the two figures entitled with English lettering 'Pretty faces and some sharp lines'.  The work proceeds with lithographs, purportedly by Professor B, caricaturing Darwinian theory by depicting usually inanimate objects a tea-kettle, a bottle of ink, the helmet of a Prussian soldier metamorphosing into humans or animals"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1680406'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b16804065",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b16804065.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b16804065",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b16804065",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b16804065-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b16804065",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b16804065, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16804065/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b16804065/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127/full/77,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 790,
+              "sizes": [
+                {
+                  "width": 77,
+                  "height": 100
+                },
+                {
+                  "width": 154,
+                  "height": 200
+                },
+                {
+                  "width": 309,
+                  "height": 400
+                },
+                {
+                  "width": 790,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6364,
+          "width": 4910,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/3e8cec18-8fca-4ba2-9c55-a997d6e86127",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 790,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c0"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c1",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/acc6a9d6-34bd-4f76-8691-2dfcdba6a9bf/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/acc6a9d6-34bd-4f76-8691-2dfcdba6a9bf",
+              "protocol": "http://iiif.io/api/image",
+              "height": 785,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 307
+                },
+                {
+                  "width": 1024,
+                  "height": 785
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4866,
+          "width": 6348,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/acc6a9d6-34bd-4f76-8691-2dfcdba6a9bf",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/acc6a9d6-34bd-4f76-8691-2dfcdba6a9bf/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 785,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/acc6a9d6-34bd-4f76-8691-2dfcdba6a9bf",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c1"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c2",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/97cd28ee-dfd8-48ba-ac36-9e49a29243d0/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/97cd28ee-dfd8-48ba-ac36-9e49a29243d0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 788,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 308
+                },
+                {
+                  "width": 1024,
+                  "height": 788
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4894,
+          "width": 6358,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/97cd28ee-dfd8-48ba-ac36-9e49a29243d0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/97cd28ee-dfd8-48ba-ac36-9e49a29243d0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 788,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/97cd28ee-dfd8-48ba-ac36-9e49a29243d0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c2"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c3",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/1a149364-db3b-4a77-aa01-2ef6d9ea2e3e/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/1a149364-db3b-4a77-aa01-2ef6d9ea2e3e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 798,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 156
+                },
+                {
+                  "width": 400,
+                  "height": 312
+                },
+                {
+                  "width": 1024,
+                  "height": 798
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4926,
+          "width": 6322,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/1a149364-db3b-4a77-aa01-2ef6d9ea2e3e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/1a149364-db3b-4a77-aa01-2ef6d9ea2e3e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 798,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1a149364-db3b-4a77-aa01-2ef6d9ea2e3e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c3"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c4",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5c005267-d81f-4d7d-a6b7-88fd6af86f53/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5c005267-d81f-4d7d-a6b7-88fd6af86f53",
+              "protocol": "http://iiif.io/api/image",
+              "height": 791,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 309
+                },
+                {
+                  "width": 1024,
+                  "height": 791
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4920,
+          "width": 6366,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/5c005267-d81f-4d7d-a6b7-88fd6af86f53",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5c005267-d81f-4d7d-a6b7-88fd6af86f53/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 791,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5c005267-d81f-4d7d-a6b7-88fd6af86f53",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c4"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c5",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d4ff1822-71f0-4d7f-8c22-e9e4389ff2cb/full/100,76/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d4ff1822-71f0-4d7f-8c22-e9e4389ff2cb",
+              "protocol": "http://iiif.io/api/image",
+              "height": 783,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 76
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 306
+                },
+                {
+                  "width": 1024,
+                  "height": 783
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4894,
+          "width": 6402,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/d4ff1822-71f0-4d7f-8c22-e9e4389ff2cb",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d4ff1822-71f0-4d7f-8c22-e9e4389ff2cb/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 783,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d4ff1822-71f0-4d7f-8c22-e9e4389ff2cb",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c5"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c6",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/221fd88a-ab77-4117-bcca-bd7130605de4/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/221fd88a-ab77-4117-bcca-bd7130605de4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 792,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 310
+                },
+                {
+                  "width": 1024,
+                  "height": 792
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4929,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/221fd88a-ab77-4117-bcca-bd7130605de4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/221fd88a-ab77-4117-bcca-bd7130605de4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 792,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/221fd88a-ab77-4117-bcca-bd7130605de4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c6"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c7",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/28a8df1e-da26-4d5c-bf80-28accff5bc7d/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/28a8df1e-da26-4d5c-bf80-28accff5bc7d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 800,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 156
+                },
+                {
+                  "width": 400,
+                  "height": 312
+                },
+                {
+                  "width": 1024,
+                  "height": 800
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4952,
+          "width": 6341,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/28a8df1e-da26-4d5c-bf80-28accff5bc7d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/28a8df1e-da26-4d5c-bf80-28accff5bc7d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 800,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/28a8df1e-da26-4d5c-bf80-28accff5bc7d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c7"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c8",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/bed837fb-38b5-4153-89af-636ac9970db2/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/bed837fb-38b5-4153-89af-636ac9970db2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 788,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 308
+                },
+                {
+                  "width": 1024,
+                  "height": 788
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4869,
+          "width": 6328,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/bed837fb-38b5-4153-89af-636ac9970db2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/bed837fb-38b5-4153-89af-636ac9970db2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 788,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bed837fb-38b5-4153-89af-636ac9970db2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c8"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c9",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/424886e7-4f40-495b-be5b-d63bdf37d1ed/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/424886e7-4f40-495b-be5b-d63bdf37d1ed",
+              "protocol": "http://iiif.io/api/image",
+              "height": 786,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 307
+                },
+                {
+                  "width": 1024,
+                  "height": 786
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4888,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/424886e7-4f40-495b-be5b-d63bdf37d1ed",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/424886e7-4f40-495b-be5b-d63bdf37d1ed/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 786,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/424886e7-4f40-495b-be5b-d63bdf37d1ed",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c9"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c10",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/123cfd52-49b4-49aa-8363-c1bf1d051ffe/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/123cfd52-49b4-49aa-8363-c1bf1d051ffe",
+              "protocol": "http://iiif.io/api/image",
+              "height": 788,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 308
+                },
+                {
+                  "width": 1024,
+                  "height": 788
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4904,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/123cfd52-49b4-49aa-8363-c1bf1d051ffe",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/123cfd52-49b4-49aa-8363-c1bf1d051ffe/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 788,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/123cfd52-49b4-49aa-8363-c1bf1d051ffe",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c10"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c11",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d79295c3-17d0-42c5-b162-70a12d4b3397/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d79295c3-17d0-42c5-b162-70a12d4b3397",
+              "protocol": "http://iiif.io/api/image",
+              "height": 788,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 308
+                },
+                {
+                  "width": 1024,
+                  "height": 788
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4875,
+          "width": 6334,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/d79295c3-17d0-42c5-b162-70a12d4b3397",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d79295c3-17d0-42c5-b162-70a12d4b3397/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 788,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d79295c3-17d0-42c5-b162-70a12d4b3397",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c11"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c12",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4f0f076b-79b3-4cad-9c03-6b986c056ae4/full/100,76/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4f0f076b-79b3-4cad-9c03-6b986c056ae4",
+              "protocol": "http://iiif.io/api/image",
+              "height": 781,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 76
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 305
+                },
+                {
+                  "width": 1024,
+                  "height": 781
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4861,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/4f0f076b-79b3-4cad-9c03-6b986c056ae4",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4f0f076b-79b3-4cad-9c03-6b986c056ae4/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 781,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4f0f076b-79b3-4cad-9c03-6b986c056ae4",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c12"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c13",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/57a4c86c-678c-4849-815c-288d3a4a20e3/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/57a4c86c-678c-4849-815c-288d3a4a20e3",
+              "protocol": "http://iiif.io/api/image",
+              "height": 785,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 306
+                },
+                {
+                  "width": 1024,
+                  "height": 785
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4920,
+          "width": 6422,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/57a4c86c-678c-4849-815c-288d3a4a20e3",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/57a4c86c-678c-4849-815c-288d3a4a20e3/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 785,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/57a4c86c-678c-4849-815c-288d3a4a20e3",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c13"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c14",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c0184db0-843d-46d6-9a6a-c515c0a68d4a/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c0184db0-843d-46d6-9a6a-c515c0a68d4a",
+              "protocol": "http://iiif.io/api/image",
+              "height": 792,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 309
+                },
+                {
+                  "width": 1024,
+                  "height": 792
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4862,
+          "width": 6286,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/c0184db0-843d-46d6-9a6a-c515c0a68d4a",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c0184db0-843d-46d6-9a6a-c515c0a68d4a/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 792,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c0184db0-843d-46d6-9a6a-c515c0a68d4a",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c14"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c15",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4cd4a78e-9693-4b3a-9d11-3ef6f7b987e7/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4cd4a78e-9693-4b3a-9d11-3ef6f7b987e7",
+              "protocol": "http://iiif.io/api/image",
+              "height": 791,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 309
+                },
+                {
+                  "width": 1024,
+                  "height": 791
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4890,
+          "width": 6332,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/4cd4a78e-9693-4b3a-9d11-3ef6f7b987e7",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4cd4a78e-9693-4b3a-9d11-3ef6f7b987e7/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 791,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4cd4a78e-9693-4b3a-9d11-3ef6f7b987e7",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c15"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c16",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/132cf69a-5e65-4e60-87e7-9bd0f14af59f/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/132cf69a-5e65-4e60-87e7-9bd0f14af59f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 789,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 154
+                },
+                {
+                  "width": 400,
+                  "height": 308
+                },
+                {
+                  "width": 1024,
+                  "height": 789
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4870,
+          "width": 6324,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/132cf69a-5e65-4e60-87e7-9bd0f14af59f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/132cf69a-5e65-4e60-87e7-9bd0f14af59f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 789,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/132cf69a-5e65-4e60-87e7-9bd0f14af59f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c16"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c17",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/556e3039-e632-4792-bddc-781575864fc2/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/556e3039-e632-4792-bddc-781575864fc2",
+              "protocol": "http://iiif.io/api/image",
+              "height": 796,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 311
+                },
+                {
+                  "width": 1024,
+                  "height": 796
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4952,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/556e3039-e632-4792-bddc-781575864fc2",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/556e3039-e632-4792-bddc-781575864fc2/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 796,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/556e3039-e632-4792-bddc-781575864fc2",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c17"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c18",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d5b402f1-b060-4560-8ce4-2fe614c1eee9/full/100,77/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d5b402f1-b060-4560-8ce4-2fe614c1eee9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 784,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 77
+                },
+                {
+                  "width": 200,
+                  "height": 153
+                },
+                {
+                  "width": 400,
+                  "height": 306
+                },
+                {
+                  "width": 1024,
+                  "height": 784
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4874,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/d5b402f1-b060-4560-8ce4-2fe614c1eee9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d5b402f1-b060-4560-8ce4-2fe614c1eee9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 784,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d5b402f1-b060-4560-8ce4-2fe614c1eee9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c18"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c19",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/cbe8d31c-baec-4c90-970f-8cf378e0664d/full/100,76/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/cbe8d31c-baec-4c90-970f-8cf378e0664d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 775,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 76
+                },
+                {
+                  "width": 200,
+                  "height": 151
+                },
+                {
+                  "width": 400,
+                  "height": 303
+                },
+                {
+                  "width": 1024,
+                  "height": 775
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4851,
+          "width": 6408,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/cbe8d31c-baec-4c90-970f-8cf378e0664d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/cbe8d31c-baec-4c90-970f-8cf378e0664d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 775,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/cbe8d31c-baec-4c90-970f-8cf378e0664d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c19"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c20",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d50908ef-e51e-4ca1-a680-d6c8961d94ac/full/100,78/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d50908ef-e51e-4ca1-a680-d6c8961d94ac",
+              "protocol": "http://iiif.io/api/image",
+              "height": 796,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 78
+                },
+                {
+                  "width": 200,
+                  "height": 155
+                },
+                {
+                  "width": 400,
+                  "height": 311
+                },
+                {
+                  "width": 1024,
+                  "height": 796
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4932,
+          "width": 6346,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/d50908ef-e51e-4ca1-a680-d6c8961d94ac",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d50908ef-e51e-4ca1-a680-d6c8961d94ac/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 796,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d50908ef-e51e-4ca1-a680-d6c8961d94ac",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c20"
+            }
+          ]
+        },
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16804065/canvas/c21",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/5b8cdefa-9061-4726-888d-c0d8fd157b47/full/100,76/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/5b8cdefa-9061-4726-888d-c0d8fd157b47",
+              "protocol": "http://iiif.io/api/image",
+              "height": 778,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 76
+                },
+                {
+                  "width": 200,
+                  "height": 152
+                },
+                {
+                  "width": 400,
+                  "height": 304
+                },
+                {
+                  "width": 1024,
+                  "height": 778
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4838,
+          "width": 6370,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16804065/imageanno/5b8cdefa-9061-4726-888d-c0d8fd157b47",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/5b8cdefa-9061-4726-888d-c0d8fd157b47/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 778,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5b8cdefa-9061-4726-888d-c0d8fd157b47",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16804065/canvas/c21"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/ad69ea18889c10fbc9b6b721fa5ea737
+++ b/tests/fixtures/http/ad69ea18889c10fbc9b6b721fa5ea737
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11602892/manifest",
+  "@type": "sc:Manifest",
+  "label": "Mr. Lambkin (right) being introduced to a ballet dancer. Lithograph after G. Cruikshank.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Mr. Lambkin (right) being introduced to a ballet dancer. Lithograph after G. Cruikshank."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Cruikshank, George"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1160289'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11602892",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11602892.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11602892",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11602892",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11602892-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11602892",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11602892, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11602892/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11602892/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11602892/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/132727d3-8e82-43b2-91f8-535210963148/full/79,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/132727d3-8e82-43b2-91f8-535210963148",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 811,
+              "sizes": [
+                {
+                  "width": 79,
+                  "height": 100
+                },
+                {
+                  "width": 158,
+                  "height": 200
+                },
+                {
+                  "width": 317,
+                  "height": 400
+                },
+                {
+                  "width": 811,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 1821,
+          "width": 1443,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11602892/imageanno/132727d3-8e82-43b2-91f8-535210963148",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/132727d3-8e82-43b2-91f8-535210963148/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 811,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/132727d3-8e82-43b2-91f8-535210963148",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11602892/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/b1387002e0724efd4310df9284f97d6a
+++ b/tests/fixtures/http/b1387002e0724efd4310df9284f97d6a
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11748412/manifest",
+  "@type": "sc:Manifest",
+  "label": "Sadi Carnot, the president of France, lies in bed having his pulse taken. Lithograph by H. de Toulouse-Lautrec, 1893.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Sadi Carnot, the president of France, lies in bed having his pulse taken. Lithograph by H. de Toulouse-Lautrec, 1893."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Toulouse-Lautrec, Henri de"
+    },
+    {
+      "label": "Description",
+      "value": "A pair of hands appear from the bottom-right hand corner, carrying a bowl of soup. Carnot holds a sheet of paper, possibly a will, which appears to bear the legend 'Benne'\n\nMarie François Sadi Carnot (18371894) was the President of the French Republic from 1887 to 1894. He was a popular and staunch defender of the republic. In the 1890s he suffered from an illness which was said to be due to liver disease. In 1893 he was the subject of a comic monologue by the variety performer Eugène Lemercier, which is illustrated in this lithograph by Toulouse-Lautrec. It shows Carnot as an invalid wrapped up in bed with a bandage round his head, being served a bowl of broth, and having his pulse taken by an élite physician. The present day battery of physical tests carried out by pathologists and radiologists did not exist in Carnot's time: academic  physicians used traditional methods of clinical examination derived from the Hippocratic writings, with a few additional techniques such as the stethoscope and endoscope. Carnot did not die of his illness: he was assassinated in 1894, an occasion which caused much grief in France and elsewhere\n\n\"Designed to illustrate the cover of the text of a monologue delivered at the Chat Noir cabaret in Montmartre, a favorite haunt of the artistic and literary avant-garde of the 1880s and 1890s. The monologue was an irreverent spoof on the president of France, Sadi Carnot, which ended with the refrain: 'If Carnot is ill, it is probably in order to be like the government'\" (Boyar, op. cit. p. 7)"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1174841'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11748412",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11748412.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11748412",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11748412",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11748412-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11748412",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11748412, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11748412/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11748412/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11748412/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 775,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3107,
+          "width": 2350,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11748412/imageanno/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11748412/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/bbb2398465f43e91dcbbb82f82592303
+++ b/tests/fixtures/http/bbb2398465f43e91dcbbb82f82592303
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b15632696/manifest",
+  "@type": "sc:Manifest",
+  "label": "A mesmeric physician taking advantage of his female patient. Colour lithograph, 1852.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A mesmeric physician taking advantage of his female patient. Colour lithograph, 1852."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1563269'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b15632696",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b15632696.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b15632696",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b15632696",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b15632696-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b15632696",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b15632696, Digicode: digpathways(Mindcraft), Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15632696/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b15632696/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b15632696/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f/full/100,73/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 749,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 73
+                },
+                {
+                  "width": 200,
+                  "height": 146
+                },
+                {
+                  "width": 400,
+                  "height": 293
+                },
+                {
+                  "width": 1024,
+                  "height": 749
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2879,
+          "width": 3935,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b15632696/imageanno/fc5e6377-f935-4d52-9f37-a86f2adb910f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 749,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b15632696/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/be807c9d16f72a96639a8693d7ee7c45
+++ b/tests/fixtures/http/be807c9d16f72a96639a8693d7ee7c45
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b1158788x/manifest",
+  "@type": "sc:Manifest",
+  "label": "A physician, a lawyer and a vicar; represented as outlandish figures. Coloured etching.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A physician, a lawyer and a vicar; represented as outlandish figures. Coloured etching."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1158788'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b1158788x",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b1158788x.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b1158788x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b1158788x",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b1158788x-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b1158788x",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b1158788x, Digicode: digpicture, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1158788x/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b1158788x/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b1158788x/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62/full/89,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 914,
+              "sizes": [
+                {
+                  "width": 89,
+                  "height": 100
+                },
+                {
+                  "width": 179,
+                  "height": 200
+                },
+                {
+                  "width": 357,
+                  "height": 400
+                },
+                {
+                  "width": 914,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2857,
+          "width": 2550,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b1158788x/imageanno/342bab57-846f-480c-b9c8-bb3174ab9d62",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 914,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b1158788x/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/c3f9e3a72010e452e819551b1e2cd824
+++ b/tests/fixtures/http/c3f9e3a72010e452e819551b1e2cd824
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b16452835/manifest",
+  "@type": "sc:Manifest",
+  "label": "A village doctress distilling eyewater. Watercolour by Thomas Rowlandson, ca. 1800 (?).",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A village doctress distilling eyewater. Watercolour by Thomas Rowlandson, ca. 1800 (?)."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Rowlandson, Thomas"
+    },
+    {
+      "label": "Description",
+      "value": "The watercolour shows a rural medical practitioner, a woman, not young, using her own urine to create a medicine which she offers for sale for rubbing on the eyes to dispel bad humours of the eye. She urinates in the right foreground into a funnel over a chemical vessel; another, younger woman urinates in the left background into a funnel placed in a barrel, and a cat urinates in the left foreground on to the ground\n\n\"Humours in the eyes\" which are mentioned on the signboard seem to have been a kind of disease, possibly cataract. The recipe book of Deborah Bragge (also called Deborah Branch), Wellcome Library MS 1343, has a recipe \"For a homour in the eyes. Take a popey head break it into half a pint of watter Lett it be ready to boil then take it off and dape the eyes with it it curred Dr Trotters childs eyes for a homour that fell in them after the small pox\"  (fol. 79r)"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1645283'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b16452835",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b16452835.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b16452835",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b16452835",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b16452835-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b16452835",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b16452835, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16452835/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b16452835/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16452835/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0/full/87,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 891,
+              "sizes": [
+                {
+                  "width": 87,
+                  "height": 100
+                },
+                {
+                  "width": 174,
+                  "height": 200
+                },
+                {
+                  "width": 348,
+                  "height": 400
+                },
+                {
+                  "width": 891,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 4072,
+          "width": 3544,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16452835/imageanno/8d1bc7b5-8e8f-4564-be51-34f211f013c0",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 891,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16452835/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/c5d8eb31502007a92c70214c25fd5e8f
+++ b/tests/fixtures/http/c5d8eb31502007a92c70214c25fd5e8f
@@ -1,0 +1,134 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11873449/manifest",
+  "@type": "sc:Manifest",
+  "label": "A barber standing with his hands in his pockets. Coloured lithograph.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A barber standing with his hands in his pockets. Coloured lithograph."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1187344'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11873449",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11873449.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11873449",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11873449",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11873449-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11873449",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11873449, Digicode: digbeard, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11873449/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11873449/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11873449/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9/full/63,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 649,
+              "sizes": [
+                {
+                  "width": 63,
+                  "height": 100
+                },
+                {
+                  "width": 127,
+                  "height": 200
+                },
+                {
+                  "width": 253,
+                  "height": 400
+                },
+                {
+                  "width": 649,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3355,
+          "width": 2125,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11873449/imageanno/58932380-28e1-4fc0-90ca-c08928ad82d9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 649,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11873449/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/caa735a4e1e802e31fd0c7a53fa21a0f
+++ b/tests/fixtures/http/caa735a4e1e802e31fd0c7a53fa21a0f
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11579328/manifest",
+  "@type": "sc:Manifest",
+  "label": "A lecture on pneumatics at the Royal Institution, London. Coloured etching by J. Gillray, 1802.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A lecture on pneumatics at the Royal Institution, London. Coloured etching by J. Gillray, 1802."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Gillray, James"
+    },
+    {
+      "label": "Description",
+      "value": "A gathering of twenty-five ladies and gentlemen in the lecture hall of the Royal Institution, London. The lecturer, identified by M.D. George as Thomas Young, demonstrates the effect of nitrous oxide by inserting a pipe attached to tubing into the mouth of Sir J.C. Hippisley whose breeches are burst by a fiery explosion. Next to the lecturer stands Humphry Davy, holding bellows. Before him are an air pump containing a frog, two vessels marked \"Hydrogen\" and \"Oxigen\", a pig's bladder, a windmill, and a bell jar. In the preparation room behind is a Nairn electrostatic machine. Among the fashionable audience are Count von Rumford and Lord Stanhope"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1157932'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11579328",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11579328.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11579328",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11579328",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11579328-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11579328",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11579328, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11579328/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11579328/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11579328/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d/full/100,73/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 745,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 73
+                },
+                {
+                  "width": 200,
+                  "height": 145
+                },
+                {
+                  "width": 400,
+                  "height": 291
+                },
+                {
+                  "width": 1024,
+                  "height": 745
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2440,
+          "width": 3356,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11579328/imageanno/4fdb5842-14c2-4e64-8adc-5e0216dd121d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 745,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11579328/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/cba488b071444ca301da6a84f35ce62c
+++ b/tests/fixtures/http/cba488b071444ca301da6a84f35ce62c
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b15751697/manifest",
+  "@type": "sc:Manifest",
+  "label": "An ape in military attire, sitting astride a hog, confronts a baboon, also in military attire, who sits astride a bear. Engraving by F. Barlow, ca. 1679/1680.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "An ape in military attire, sitting astride a hog, confronts a baboon, also in military attire, who sits astride a bear. Engraving by F. Barlow, ca. 1679/1680."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Barlow, Francis"
+    },
+    {
+      "label": "Description",
+      "value": "The animals are assisted by two further apes by their sides.  A woodcock and an owl mark the battle with the sound of their horns"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1575169'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b15751697",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b15751697.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b15751697",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b15751697",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b15751697-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b15751697",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b15751697, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15751697/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b15751697/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b15751697/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df/full/100,80/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df",
+              "protocol": "http://iiif.io/api/image",
+              "height": 818,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 80
+                },
+                {
+                  "width": 200,
+                  "height": 160
+                },
+                {
+                  "width": 400,
+                  "height": 319
+                },
+                {
+                  "width": 1024,
+                  "height": 818
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2664,
+          "width": 3336,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b15751697/imageanno/3a03a4c0-8ca1-474a-aea4-25d768fc42df",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 818,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b15751697/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/cd3a373d48e900aed32476b5025ed7bf
+++ b/tests/fixtures/http/cd3a373d48e900aed32476b5025ed7bf
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11750832/manifest",
+  "@type": "sc:Manifest",
+  "label": "Mediaeval torturers torture a gout-sufferer; representing the view atributed to Fabricius von Hilden that gout could be cured by torture. Colour process print after D.T. de Losques, 1910.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Mediaeval torturers torture a gout-sufferer; representing the view atributed to Fabricius von Hilden that gout could be cured by torture. Colour process print after D.T. de Losques, 1910."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Losques, Daniel Thouroude de"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175083'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11750832",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11750832.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11750832",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11750832",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11750832-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11750832",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11750832, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11750832/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11750832/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11750832/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9/full/83,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 849,
+              "sizes": [
+                {
+                  "width": 83,
+                  "height": 100
+                },
+                {
+                  "width": 166,
+                  "height": 200
+                },
+                {
+                  "width": 332,
+                  "height": 400
+                },
+                {
+                  "width": 849,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7081,
+          "width": 5871,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11750832/imageanno/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 849,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11750832/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/cd5dab1704798b8e340825e8d0664b2f
+++ b/tests/fixtures/http/cd5dab1704798b8e340825e8d0664b2f
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11757619/manifest",
+  "@type": "sc:Manifest",
+  "label": "A gynaecologist strokes his long red beard. Colour process print by C. Josef, c. 1930.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A gynaecologist strokes his long red beard. Colour process print by C. Josef, c. 1930."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Josef, Carl"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175761'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11757619",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11757619.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11757619",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11757619",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11757619-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11757619",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11757619, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11757619/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11757619/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11757619/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c/full/64,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 659,
+              "sizes": [
+                {
+                  "width": 64,
+                  "height": 100
+                },
+                {
+                  "width": 129,
+                  "height": 200
+                },
+                {
+                  "width": 258,
+                  "height": 400
+                },
+                {
+                  "width": 659,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3485,
+          "width": 2244,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11757619/imageanno/be254116-e199-424d-ab74-ab8082e2dc0c",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 659,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11757619/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/d106b48c93aff7243c543b5000741c90
+++ b/tests/fixtures/http/d106b48c93aff7243c543b5000741c90
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11584956/manifest",
+  "@type": "sc:Manifest",
+  "label": "A swollen and inflamed foot: gout is represented by an attacking demon. Coloured soft-ground etching by J. Gillray, 1799.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A swollen and inflamed foot: gout is represented by an attacking demon. Coloured soft-ground etching by J. Gillray, 1799."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Gillray, James"
+    },
+    {
+      "label": "Description",
+      "value": "Gout is an intensely painful disease of the joints of the fingers and toes, and sometimes other joints. In traditional western medicine it is associated with the infusion or drip (Latin gutta, hence the English word gout) of wet humours (phlegm and/or blood) into the cavity of a damaged organ. Although it was regarded by many as incurable, there was a demand for treatments, which included a diet designed to rebalance the proportion of humours in the body as a whole, and bloodletting positioned to draw blood away from the gouty organ. Some students of gout theorized that there was a \"morbid humour\" specific to gout, and, a corresponding specific remedy which God had placed in the plant colchicum, the metal gold, or some other substance. In 1848, a year of revolutions in Europe, such a \"morbid humour\" was indeed identified as a naturally occurring chemical, uric acid. In another period of rapid change, the 1960s, a corresponding remedy was found when staff at the Burroughs Wellcome laboratories in the USA discovered the medicine allopurinol\n\nAs Porter and Rousseau point out, Gillray's print The gout (1799) is unique in restricting its focus to the diseased organ. There are dozens of other Georgian and earlier prints of gouty people, but they all show the whole patient in a social context. Gillray's depiction isolates the painful organ from the tragi-comedy of manners surrounding the disease: the face of the sufferer, the furnishings of the room, and the friends offering comfort are all excluded, perhaps representing the ability of the disease to block out everything else from the victim's mind"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1158495'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11584956",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11584956.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11584956",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11584956",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11584956-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11584956",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11584956, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11584956/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11584956/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11584956/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d/full/100,73/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 752,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 73
+                },
+                {
+                  "width": 200,
+                  "height": 147
+                },
+                {
+                  "width": 400,
+                  "height": 294
+                },
+                {
+                  "width": 1024,
+                  "height": 752
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2444,
+          "width": 3328,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11584956/imageanno/87f07a8b-1c59-4024-b335-5917ef01377d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 752,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11584956/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/d12fa377bc11807c096319b62a9b0aa5
+++ b/tests/fixtures/http/d12fa377bc11807c096319b62a9b0aa5
@@ -1,0 +1,138 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11740644/manifest",
+  "@type": "sc:Manifest",
+  "label": "In a room filled with skulls of the famous, the phrenologist Gall examines William Pitt the Younger and Gustavus IV, the King of Sweden, both currently plagued by Napoleon. Coloured etching, 1806.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "In a room filled with skulls of the famous, the phrenologist Gall examines William Pitt the Younger and Gustavus IV, the King of Sweden, both currently plagued by Napoleon. Coloured etching, 1806."
+    },
+    {
+      "label": "Description",
+      "value": "Pitt the Younger had a chequered ministry and was prime minister during the war with France in 1793. Gustavus IV was also an opponent of Napoleon and was deposed due to his insanity in 1806. Helfand (op. cit. note 10) suggests that both are consulting Gall for help in containing Napoléon's domination of Europe"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1174064'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11740644",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11740644.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11740644",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11740644",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11740644-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11740644",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11740644, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11740644/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11740644/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11740644/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b/full/100,90/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 920,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 90
+                },
+                {
+                  "width": 200,
+                  "height": 180
+                },
+                {
+                  "width": 400,
+                  "height": 359
+                },
+                {
+                  "width": 1024,
+                  "height": 920
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2560,
+          "width": 2850,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11740644/imageanno/6a72935f-0d3e-426b-8162-975cfc399e1b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 920,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11740644/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/ec96516420efd0829cd545eee83c470d
+++ b/tests/fixtures/http/ec96516420efd0829cd545eee83c470d
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11855757/manifest",
+  "@type": "sc:Manifest",
+  "label": "Phrenological head of Lord Ellenborough as Governor General of India 1841-1844. Lithograph, ca. 1844.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Phrenological head of Lord Ellenborough as Governor General of India 1841-1844. Lithograph, ca. 1844."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Follit, J"
+    },
+    {
+      "label": "Description",
+      "value": "The lettering refers to the phrenological organ allocated to each section of the head. 1. Weight: Ellenborough carries a door marked 'Samnouth', i.e. the gates of the temple of Somnāth in Gujarat, which he brought back from Afghanistan, reversing the Afghan policy of his predecessor Lord Auckland (hence \"aukward in the lettering\"). 2. Ideality: wearing civilian clothes, he looks into a mirror and sees himself as a soldier in uniform. 3. Locality: on receiving his recall from India, he sobs into a handkerchief, a scroll marked \"Recall\" lies on the ground. 4. Veneration: he worships a statue of a Hindu deity. 5. Comparison: Ellenborough facing in opposite directions, on the left holding a scroll saying \"The insults of a thousand years are avenged\", on the right holding one saying \"The misgovernment of two years is avenged: \". 6. Acquisitiveness: he presides over a coffer stuffed with coins, inscribed \"Gwalior\", referring to Ellenborough's seizure of the state of Gwalior in December 1843. 7. Secretiveness: Ellenborough is manacled with a big padlock, referring to control of his reputation; the lettering, \"Lock; on the understanding\", refers to John Locke's An essay concerning human understanding. 8. Combativeness: the government on the left and the directors of the East India Company on the right try to pull Ellenborough in their direction. 9. Language: Ellenborough writes a dispatch \"I came, I saw, I conqured [sic]\". The last organ is \"Unascertained\", numbered \"?\", and the unascertained question is \"Whether his appointment took place after dinner, or not-\""
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1185575'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11855757",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11855757.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11855757",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11855757",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11855757-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11855757",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11855757, Digicode: digrr, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11855757/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11855757/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11855757/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 749,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 293,
+                  "height": 400
+                },
+                {
+                  "width": 749,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 7828,
+          "width": 5728,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11855757/imageanno/ffe0f698-0d17-4a3f-b52f-96ff136a272e",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 749,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11855757/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/ee69f08524e6a29489f17234ca856cd5
+++ b/tests/fixtures/http/ee69f08524e6a29489f17234ca856cd5
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11951266/manifest",
+  "@type": "sc:Manifest",
+  "label": "A young dancer trying to escape winged figures with men's heads. Etching by F. Goya, 1796/1798.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A young dancer trying to escape winged figures with men's heads. Etching by F. Goya, 1796/1798."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Goya, Francisco"
+    },
+    {
+      "label": "Description",
+      "value": "\"The subject of this etching is the harrassment of a beautiful woman by grotesque, deformed, bird-like creatures representing desire, temptation and deceit. The Prado manuscript points out, \"She who wants to be caught never escapes\". The other commentaries refer to the scene as Godoy, the Prime Minister, pursuing \"Duten\" or \"Dutim\". The latter may be a code name for Queen Maria Luisa\"--Pérez-Sanchez and Gállego, loc. cit."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1195126'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11951266",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11951266.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11951266",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11951266",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11951266-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11951266",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11951266, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11951266/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11951266/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11951266/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 723,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 723,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3162,
+          "width": 2232,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11951266/imageanno/7920af80-77c4-431a-85d2-f19366a18d6b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 723,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11951266/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/f43d9cdb2b6da903faa85d3e2c687ed5
+++ b/tests/fixtures/http/f43d9cdb2b6da903faa85d3e2c687ed5
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11759355/manifest",
+  "@type": "sc:Manifest",
+  "label": "A donkey as a physician taking the pulse of a dying man. Aquatint with etching by F. Goya, ca. 1797.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A donkey as a physician taking the pulse of a dying man. Aquatint with etching by F. Goya, ca. 1797."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Goya, Francisco"
+    },
+    {
+      "label": "Description",
+      "value": "According to A.M. Hind, History of engraving and etching, London, 1908, p. 253ff, the donkey represents Galinsoya [i.e. Galinsoga?], botanist, physician to the Queen of Spain, and surgeon to Manuel de Godoy, Prime Minister of Spain"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175935'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11759355",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11759355.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759355",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11759355",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11759355-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11759355",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11759355, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759355/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11759355/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11759355/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 713,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 713,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 3225,
+          "width": 2244,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11759355/imageanno/de208c70-a655-4578-9b37-35b96a36e800",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 713,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11759355/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/f601489008c4266a2b0f8644a71a5531
+++ b/tests/fixtures/http/f601489008c4266a2b0f8644a71a5531
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11592734/manifest",
+  "@type": "sc:Manifest",
+  "label": "A sailor with a bandaged eye consulting a quack doctor. Coloured etching by I. Cruikshank, 1807?, after G.M. Woodward.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A sailor with a bandaged eye consulting a quack doctor. Coloured etching by I. Cruikshank, 1807?, after G.M. Woodward."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M; Cruikshank, Isaac"
+    },
+    {
+      "label": "Description",
+      "value": "The sailor says: \"You must know doctor I have got a bit of a confusion on my larboard cheek from a chance shot, and as I dont think it of consequence enough for our ships surgeon, I bore down to you, after overhawling a long list of you cures - but I suppose from the messmate in the cabin there; you dont always make a return of the killed and wounded.\" The quack replies: \"Sir, my rule of practice is this, there is pen, ink, and paper, - sign a certificate of your cure, and I'll take you in hand immediatly on paying down two guineas!\""
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159273'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11592734",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11592734.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11592734",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11592734",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11592734-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11592734",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11592734, Digicode: digpathways(Collectors), Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11592734/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11592734/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11592734/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f/full/100,69/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f",
+              "protocol": "http://iiif.io/api/image",
+              "height": 706,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 69
+                },
+                {
+                  "width": 200,
+                  "height": 138
+                },
+                {
+                  "width": 400,
+                  "height": 276
+                },
+                {
+                  "width": 1024,
+                  "height": 706
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2276,
+          "width": 3300,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11592734/imageanno/c5212b1d-518e-40f1-a1b5-2ed86165a92f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 706,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11592734/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/fdcceac9df2636511af50d1856c49103
+++ b/tests/fixtures/http/fdcceac9df2636511af50d1856c49103
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b11757280/manifest",
+  "@type": "sc:Manifest",
+  "label": "A goat-headed man caresses a sleeping ewe-headed woman; representing the notion of animal magnetism and its application by physicians. Etching after M. Voltz (?), 1815.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "A goat-headed man caresses a sleeping ewe-headed woman; representing the notion of animal magnetism and its application by physicians. Etching after M. Voltz (?), 1815."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Voltz, Michael"
+    },
+    {
+      "label": "Description",
+      "value": "The goat-doctor has removed his jacket and rolled up his sleeves. A clyster appears to be emerging from his jacket pocket. The painting on the wall shows an eagle descending on a classically dressed woman, who sits next to a cup from which ascends a snake. This may refer to one of the stories from Ovid's 'Metamorphoses', which lying next to the woman on the bed. Otto Baur traces the meaning of this print back to an anonymous French print of 1784 called 'Le doigt magique ou le magnetisme animal' which is lettered 'simium semper simius', a parody of Hahnemann's slogan on the treatment of like with like. This much discussed notion was thus compounded with the controversy over Mesmer's researches. In the French print however, the woman is still human"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1175728'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons, Attribution license</a>.<br/><br/>This licence permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b11757280",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b11757280.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b11757280",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b11757280",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11757280-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11757280",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11757280, Digicode: digpathways(Mindcraft), Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11757280/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b11757280/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b11757280/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 727,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 727,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2946,
+          "width": 2092,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b11757280/imageanno/ba2ccaf1-308f-4afb-934f-448cc71cf50b",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 727,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b11757280/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/http/fef0c260580716321df338ae12fdfc91
+++ b/tests/fixtures/http/fef0c260580716321df338ae12fdfc91
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b15649945/manifest",
+  "@type": "sc:Manifest",
+  "label": "Gladstone and three other politicians involved in Irish politics as Christmas drinking companions. Lithograph by Tom Merry, 24 December 1887.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "Gladstone and three other politicians involved in Irish politics as Christmas drinking companions. Lithograph by Tom Merry, 24 December 1887."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Merry, Tom"
+    },
+    {
+      "label": "Description",
+      "value": "They are wearing top hats and tails and are walking along a pavement covered with snow. The second man from the left is Gladstone. The others have not been identified. They are also portrayed in a Tom Merry print of 18 December 1886, 'Scenes of the Liberal Union. Incorrigibles discharged' (Wellcome Library no. 565060i). In view of the mention of \"union\", they might be Liberal Unionists who broke away from the Liberals in 1886, but they do not resemble the best known Unionists such as Lord Hartington or Goschen"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1564994'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b15649945",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b15649945.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b15649945",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b15649945",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b15649945-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b15649945",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b15649945, Digicode: digicon, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15649945/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b15649945/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b15649945/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d/full/100,68/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d",
+              "protocol": "http://iiif.io/api/image",
+              "height": 693,
+              "width": 1024,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 68
+                },
+                {
+                  "width": 200,
+                  "height": 135
+                },
+                {
+                  "width": 400,
+                  "height": 271
+                },
+                {
+                  "width": 1024,
+                  "height": 693
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 2272,
+          "width": 3356,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b15649945/imageanno/02739ede-8778-4c22-86bf-03e3c8d85e6d",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 693,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b15649945/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wellcome-collection.json
+++ b/tests/fixtures/wellcome-collection.json
@@ -1,0 +1,1898 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/service/collections/genres/Caricatures/",
+  "@type": "sc:Collection",
+  "label": " Genre: Caricatures",
+  "manifests": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16736400/manifest",
+      "@type": "sc:Manifest",
+      "label": "The apparent revival of a dead man by galvanism. Drawing attributed to G.M. Woodward.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b16736400",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b16736400.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b16736400",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b16736400",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11672420/manifest",
+      "@type": "sc:Manifest",
+      "label": "Physicians expressing their thanks to influenza. Coloured etching attributed to Temple West, 1803.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/0869932c-6f96-4a49-beba-9cf5e3b49f0f",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11672420",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11672420.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11672420",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11672420",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11784520/manifest",
+      "@type": "sc:Manifest",
+      "label": "Doctor Botherum, an itinerant medicine vendor (perhaps based on Doctor Bossy) selling his wares on stage with the aid of assistants to a raucous crowd. Coloured etching by T. Rowlandson, 1800.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/bc4c3ebb-68bc-471d-8813-d36291024c87",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11784520",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11784520.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11784520",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11784520",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11599820/manifest",
+      "@type": "sc:Manifest",
+      "label": "Sixteen feet in profile, of women and men: a parody of phrenology. Coloured etching.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/3cab2dd3-c56c-4d7e-b6e7-42cc053be2d0",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11599820",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11599820.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11599820",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11599820",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11757280/manifest",
+      "@type": "sc:Manifest",
+      "label": "A goat-headed man caresses a sleeping ewe-headed woman; representing the notion of animal magnetism and its application by physicians. Etching after M. Voltz (?), 1815.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/ba2ccaf1-308f-4afb-934f-448cc71cf50b",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11757280",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11757280.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11757280",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11757280",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759380/manifest",
+      "@type": "sc:Manifest",
+      "label": "A woman covers her eyes as she steals the teeth of a hanged man. Aquatint with etching by F. Goya, ca. 1797.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/4359f99e-bfe7-488d-ad71-ae29a183b92b",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11759380",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11759380.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759380",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11759380",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759021/manifest",
+      "@type": "sc:Manifest",
+      "label": "A family threatened by influenza is prepared for a large scale bloodletting. Coloured etching, 18--.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/7afd9040-aece-4eb8-b1ea-d611c2cdfef6",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11759021",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11759021.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759021",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11759021",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11835151/manifest",
+      "@type": "sc:Manifest",
+      "label": "A nightwatchman disturbs a body-snatcher who has dropped the stolen corpse he had been carrying in a hamper, while the anatomist runs away. Etching with engraving by W. Austin, 1773.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/0eeca15a-8387-4203-b342-48200c591ecd",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11835151",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11835151.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11835151",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11835151",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11950791/manifest",
+      "@type": "sc:Manifest",
+      "label": "A futuristic vision: the advance of technology leads to rapid transport, sophisticated tastes among the masses, mechanization, and extravagant building projects. Coloured etching by W. Heath, 1829.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/96d33b64-a267-4e7d-86b6-24c24cc775f5",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11950791",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11950791.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11950791",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11950791",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11598803/manifest",
+      "@type": "sc:Manifest",
+      "label": "A monster being fed baskets of infants and excreting them with horns; symbolising vaccination and its effects. Etching by C. Williams, 1802(?).",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/f1f113b7-be9b-492a-8411-8b43c90d004f",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11598803",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11598803.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11598803",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11598803",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11589723/manifest",
+      "@type": "sc:Manifest",
+      "label": "A quack doctor irresponsibly dispensing his potions. Coloured lithograph.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/0cb1db0c-7fc6-4df6-8b06-d6bbf6f85991",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11589723",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11589723.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11589723",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11589723",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11879853/manifest",
+      "@type": "sc:Manifest",
+      "label": "A barber's shop. Coloured etching with aquatint by T. Rowlandson, 178-, after W.H. Bunbury.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/624be8f0-abb1-4a76-93e0-966337409691",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11879853",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11879853.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11879853",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11879853",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11740644/manifest",
+      "@type": "sc:Manifest",
+      "label": "In a room filled with skulls of the famous, the phrenologist Gall examines William Pitt the Younger and Gustavus IV, the King of Sweden, both currently plagued by Napoleon. Coloured etching, 1806.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/6a72935f-0d3e-426b-8162-975cfc399e1b",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11740644",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11740644.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11740644",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11740644",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11894945/manifest",
+      "@type": "sc:Manifest",
+      "label": "A man so engrossed in news of the French Revolution  that he unwittingly sets his wig alight with his candle. Etching, 1789.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/ebdb2d63-b0c0-4f6c-bd96-27a35d889200",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11894945",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11894945.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11894945",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11894945",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15649945/manifest",
+      "@type": "sc:Manifest",
+      "label": "Gladstone and three other politicians involved in Irish politics as Christmas drinking companions.  Lithograph by Tom Merry, 24 December 1887.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/02739ede-8778-4c22-86bf-03e3c8d85e6d",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b15649945",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b15649945.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b15649945",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b15649945",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16804065/manifest",
+      "@type": "sc:Manifest",
+      "label": "Evolution of household articles, animals etc. according to Darwin's doctrine. Colour lithographs by Fr. Schmidt, ca. 187-(?).",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8cec18-8fca-4ba2-9c55-a997d6e86127",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b16804065",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b16804065.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b16804065",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b16804065",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11951266/manifest",
+      "@type": "sc:Manifest",
+      "label": "A young dancer trying to escape winged figures with men's heads. Etching by F. Goya, 1796/1798.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/7920af80-77c4-431a-85d2-f19366a18d6b",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11951266",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11951266.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11951266",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11951266",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11957347/manifest",
+      "@type": "sc:Manifest",
+      "label": "A hooded alchemist at a furnace; above him hang dead animals: caricature. Watercolour painting.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/781fa833-7851-4a19-bd0f-84436898a089",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11957347",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11957347.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11957347",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11957347",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11598761/manifest",
+      "@type": "sc:Manifest",
+      "label": "Edward Jenner vaccinating patients in the Smallpox and Inoculation Hospital at St. Pancras: the patients develop features of cows. Coloured etching by J. Gillray, 1802.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/2def7b9e-a8d2-41c1-bb94-3e62e57f89a7",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11598761",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11598761.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11598761",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11598761",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11748412/manifest",
+      "@type": "sc:Manifest",
+      "label": "Sadi Carnot, the president of France, lies in bed having his pulse taken. Lithograph by H. de Toulouse-Lautrec, 1893.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/0c94dc98-1e0c-4b69-bf51-01ac96b47f5e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11748412",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11748412.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11748412",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11748412",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11651222/manifest",
+      "@type": "sc:Manifest",
+      "label": "A figure dressed in a cholera safety suit. Coloured etching after J. Petzl (?), ca. 1832.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/1796f0a8-18c8-4d74-a17b-5f7af0db117d",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11651222",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11651222.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11651222",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11651222",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11750832/manifest",
+      "@type": "sc:Manifest",
+      "label": "Mediaeval torturers torture a gout-sufferer; representing the view atributed to Fabricius von Hilden that gout could be cured by torture. Colour process print after D.T. de Losques, 1910.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/d6bc7317-4e51-49fc-b4b9-5cc19d47f5e9",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11750832",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11750832.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11750832",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11750832",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11949442/manifest",
+      "@type": "sc:Manifest",
+      "label": "Lord Melbourne and Lord John Russell as schoolboys at a class given by Sir Robert Peel: Lord Brougham peeps from behind a door. Coloured lithograph by H.B. (John Doyle), 1841.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/9f3d66cc-5282-4b34-bf07-3990acd6a63e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11949442",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11949442.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11949442",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11949442",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11603562/manifest",
+      "@type": "sc:Manifest",
+      "label": "An alchemist using a crown-shaped bellows to blow the flames of a furnace and heat a glass vessel in which the House of Commons is distilled; representing the dissolution of parliament by Pitt. Coloured etching by J. Gillray, 1796.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/80b2c4d1-33bb-4306-a2b4-0502f2e5c6bf",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11603562",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11603562.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11603562",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11603562",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11602892/manifest",
+      "@type": "sc:Manifest",
+      "label": "Mr. Lambkin (right) being introduced to a ballet dancer. Lithograph after G. Cruikshank.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/132727d3-8e82-43b2-91f8-535210963148/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/132727d3-8e82-43b2-91f8-535210963148",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11602892",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11602892.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11602892",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11602892",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11592734/manifest",
+      "@type": "sc:Manifest",
+      "label": "A sailor with a bandaged eye consulting a quack doctor. Coloured etching by I. Cruikshank, 1807?, after G.M. Woodward.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/c5212b1d-518e-40f1-a1b5-2ed86165a92f",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11592734",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11592734.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11592734",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11592734",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16452835/manifest",
+      "@type": "sc:Manifest",
+      "label": "A village doctress distilling eyewater. Watercolour by Thomas Rowlandson, ca. 1800 (?).",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/8d1bc7b5-8e8f-4564-be51-34f211f013c0",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b16452835",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b16452835.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b16452835",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b16452835",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11759355/manifest",
+      "@type": "sc:Manifest",
+      "label": "A donkey as a physician taking the pulse of a dying man. Aquatint with etching by F. Goya, ca. 1797.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/de208c70-a655-4578-9b37-35b96a36e800",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11759355",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11759355.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11759355",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11759355",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11584956/manifest",
+      "@type": "sc:Manifest",
+      "label": "A swollen and inflamed foot: gout is represented by an attacking demon. Coloured soft-ground etching by J. Gillray, 1799.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/87f07a8b-1c59-4024-b335-5917ef01377d",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11584956",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11584956.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11584956",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11584956",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15632696/manifest",
+      "@type": "sc:Manifest",
+      "label": "A mesmeric physician taking advantage of his female patient. Colour lithograph, 1852.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/fc5e6377-f935-4d52-9f37-a86f2adb910f",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b15632696",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b15632696.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b15632696",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b15632696",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11617457/manifest",
+      "@type": "sc:Manifest",
+      "label": "Phrenological head of Sir Robert Peel as Prime Minister of the United Kingdom. Lithograph, ca. 1844.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/1a62f439-99cd-4780-9868-3b5df335e81e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11617457",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11617457.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11617457",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11617457",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b15751697/manifest",
+      "@type": "sc:Manifest",
+      "label": "An ape in military attire, sitting astride a hog, confronts a baboon, also in military attire, who sits astride a bear. Engraving by F. Barlow, ca. 1679/1680.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/3a03a4c0-8ca1-474a-aea4-25d768fc42df",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b15751697",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b15751697.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b15751697",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b15751697",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b14601308/manifest",
+      "@type": "sc:Manifest",
+      "label": "An itinerant doctor, by a subterfuge, cures an undergraduate hoaxer of his supposed maladies of lying and bad memory. Coloured etching by T. Rowlandson, 1807, after G.M. Woodward.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/59ffd0d4-e103-45ba-8aff-dd524427490b",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b14601308",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b14601308.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b14601308",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b14601308",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11579328/manifest",
+      "@type": "sc:Manifest",
+      "label": "A lecture on pneumatics at the Royal Institution, London. Coloured etching by J. Gillray, 1802.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/4fdb5842-14c2-4e64-8adc-5e0216dd121d",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11579328",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11579328.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11579328",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11579328",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11746828/manifest",
+      "@type": "sc:Manifest",
+      "label": "An exotic doctor magnetises a young woman; her husband looks on. Lithograph by C. Jacque, c. 1843.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/776dac2d-177a-463f-be61-2af87fa1723e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11746828",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11746828.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11746828",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11746828",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11742148/manifest",
+      "@type": "sc:Manifest",
+      "label": "Five antiquaries look through magnifying glasses at objects. Coloured lithograph after L. Boilly, 1823.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/99c39520-ee16-4857-8d7e-60e326f2bd41",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11742148",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11742148.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11742148",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11742148",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11603458/manifest",
+      "@type": "sc:Manifest",
+      "label": "William Pitt the younger and his ministers as anatomists dissecting the body of the Prince of Wales; representing Pitt's reduction of the powers of the regent. Coloured etching by Thomas Rowlandson, 1788/1789.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/5a3e66bd-8a05-4cc1-b01c-fe0b0c3ddc95",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11603458",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11603458.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11603458",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11603458",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11589668/manifest",
+      "@type": "sc:Manifest",
+      "label": "A new apothecary's shop open for business, with parody advertisements for different potions; representing the remedies required for different professions and social types. Coloured etching after G.M. Woodward, 1802.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/9342cb81-1b36-4097-89e6-7d20186b4399",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11589668",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11589668.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11589668",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11589668",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11599509/manifest",
+      "@type": "sc:Manifest",
+      "label": "An operator treating the carbuncled nose of an obese patient with \"Perkins's tractors\". Coloured aquatint after J. Gillray, 1801.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/53e2e36d-ce2f-47b1-9cab-db861580aa25",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11599509",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11599509.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11599509",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11599509",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11873449/manifest",
+      "@type": "sc:Manifest",
+      "label": "A barber standing with his hands in his pockets. Coloured lithograph.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/58932380-28e1-4fc0-90ca-c08928ad82d9",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11873449",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11873449.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11873449",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11873449",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11600299/manifest",
+      "@type": "sc:Manifest",
+      "label": "A decrepit man screaming in pain from gout, rheumatism and catarrh; represented as three tormenting devils. Coloured etching by J. Cawse, 1809, after G.M. Woodward.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/a4d8c1b1-046a-4f1a-b04c-8fd10e42bc57",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11600299",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11600299.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11600299",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11600299",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1175820x/manifest",
+      "@type": "sc:Manifest",
+      "label": "A rich miser eating humble food. Coloured etching after G. Piattoli, c. 1800.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/684c6426-5122-4827-8086-34d67b9e0d47",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b1175820x",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b1175820x.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b1175820x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b1175820x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1159987x/manifest",
+      "@type": "sc:Manifest",
+      "label": "A man in bed with vegetables sprouting from all parts of his body; as a result of taking an overdose of James Morison's vegetable pills. Coloured lithograph by C.J. Grant, 1831.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/7f76d636-d450-4096-a1d4-65a2f24db6bc",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b1159987x",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b1159987x.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b1159987x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b1159987x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29357998/manifest",
+      "@type": "sc:Manifest",
+      "label": "Caricatural Mediaeval / Renaissance medical practitioners.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/73ebe57c-26f0-4d02-bf54-177bc22055b8",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b29357998",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b29357998.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b29357998",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b29357998",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11855757/manifest",
+      "@type": "sc:Manifest",
+      "label": "Phrenological head of Lord Ellenborough as Governor General of India 1841-1844. Lithograph, ca. 1844.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/ffe0f698-0d17-4a3f-b52f-96ff136a272e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11855757",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11855757.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11855757",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11855757",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11944377/manifest",
+      "@type": "sc:Manifest",
+      "label": "Two young men are approached by a prostitute: she is a clothed skeleton holding a made-up mask in front of her face, representing syphilis. Lithograph by J.J. Grandville, 1830.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/1ead647d-03be-48a7-88cc-43debcc75281",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11944377",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11944377.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11944377",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11944377",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11743918/manifest",
+      "@type": "sc:Manifest",
+      "label": "A crippled man and a blind man go to court; the lawyer eats oysters and gives them the empty shells. Mezzotint, 1779.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/20bfd125-4aef-4abe-8924-96cae2dc994e",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11743918",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11743918.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11743918",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11743918",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11757619/manifest",
+      "@type": "sc:Manifest",
+      "label": "A gynaecologist strokes his long red beard. Colour process print by C. Josef, c. 1930.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/be254116-e199-424d-ab74-ab8082e2dc0c",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11757619",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11757619.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11757619",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11757619",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16763269/manifest",
+      "@type": "sc:Manifest",
+      "label": "Cartoon scenes featuring condoms representing a safe sex advertisement by the Folkhälsoinstitutet RFSU och Landstinget Förebygger AIDS. Colour lithograph by L. Nitka, ca. 1995.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/23bc7fed-11a0-4f27-8c5c-cea2aaf68c65",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b16763269",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b16763269.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b16763269",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b16763269",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b11602399/manifest",
+      "@type": "sc:Manifest",
+      "label": "A woman dropping her porcelain tea-cup in horror upon discovering the monstrous contents of a magnified drop of Thames water; revealing the impurity of London drinking water. Coloured etching by W. Heath, 1828.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/c45bce25-c327-466e-baf2-5b2ac31b96b5",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b11602399",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b11602399.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b11602399",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b11602399",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1165711x/manifest",
+      "@type": "sc:Manifest",
+      "label": "Chang and Eng the Siamese twins, eating and drinking to excess. Coloured etching by W. Heath, 1829.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/2ef0161c-0145-4424-ad3a-8c883282b134",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b1165711x",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b1165711x.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b1165711x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b1165711x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1676321x/manifest",
+      "@type": "sc:Manifest",
+      "label": "A calendar for the year 1994 by Nitka featuring cartoon scenes with condoms; produced by the Folkhälsoinstitutet RFSU [?]. Colour lithograph, ca. 1994.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/60622b55-5548-4f81-90cd-fd886acef5bb",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b1676321x",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b1676321x.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b1676321x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b1676321x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b1158788x/manifest",
+      "@type": "sc:Manifest",
+      "label": "A physician, a lawyer and a vicar; represented as outlandish figures. Coloured etching.",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/342bab57-846f-480c-b9c8-bb3174ab9d62",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b1158788x",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b1158788x.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b1158788x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b1158788x",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b29353427/manifest",
+      "@type": "sc:Manifest",
+      "label": "The Indian Charivari album :vol. 1",
+      "thumbnail": {
+        "@id": "https://dlcs.io/iiif-img/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f/full/!1024,1024/0/default.jpg",
+        "@type": "dctypes:Image",
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "https://dlcs.io/iiif-img/wellcome/1/ddf9b319-7fd5-4a0c-bd24-15694508c01f",
+          "profile": "http://iiif.io/api/image/2/level1.json"
+        }
+      },
+      "related": {
+        "@id": "https://wellcomelibrary.org/item/b29353427",
+        "format": "text/html"
+      },
+      "seeAlso": [
+        {
+          "@id": "https://wellcomelibrary.org/data/b29353427.json",
+          "format": "application/json",
+          "profile": "http://wellcomelibrary.org/profiles/res"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/schemaorg/b29353427",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/schema"
+        },
+        {
+          "@id": "https://wellcomelibrary.org/resource/dublincore/b29353427",
+          "format": "application/ld+json",
+          "profile": "http://iiif.io/community/profiles/discovery/dc"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wellcome-manifest.json
+++ b/tests/fixtures/wellcome-manifest.json
@@ -1,0 +1,142 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://wellcomelibrary.org/iiif/b16736400/manifest",
+  "@type": "sc:Manifest",
+  "label": "The apparent revival of a dead man by galvanism. Drawing attributed to G.M. Woodward.",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": "The apparent revival of a dead man by galvanism. Drawing attributed to G.M. Woodward."
+    },
+    {
+      "label": "Author(s)",
+      "value": "Woodward, G. M"
+    },
+    {
+      "label": "Description",
+      "value": "Two men express astonishment as a young man sits up from his bed, apparently stimulated by an object tended towards him by a third man. Another man hiding behind the bed pushes the young man upwards with his palm against the young man's back"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    },
+    {
+      "label": "",
+      "value": "<a href='https://search.wellcomelibrary.org/iii/encore/record/C__Rb1673640'>View full catalogue record</a>"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "You have permission to make copies of this work under a <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons, Attribution, Non-commercial license</a>.<br/><br/>Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target=\"_top\" href=\"http://creativecommons.org/licenses/by-nc/4.0/legalcode\">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Library."
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "logo": "https://wellcomelibrary.org/assets/img/squarelogo64.png",
+  "related": {
+    "@id": "https://wellcomelibrary.org/item/b16736400",
+    "format": "text/html"
+  },
+  "seeAlso": [
+    {
+      "@id": "https://wellcomelibrary.org/data/b16736400.json",
+      "format": "application/json",
+      "profile": "http://wellcomelibrary.org/profiles/res"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/schemaorg/b16736400",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/schema"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/resource/dublincore/b16736400",
+      "format": "application/ld+json",
+      "profile": "http://iiif.io/community/profiles/discovery/dc"
+    }
+  ],
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b16736400-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b16736400",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b16736400, Digicode: n/a, Collection code: n/a"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b16736400/sequence/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://dlcs.io/pdf/wellcome/pdf-item/b16736400/0",
+        "format": "application/pdf",
+        "label": "Download as PDF"
+      },
+      "canvases": [
+        {
+          "@id": "https://wellcomelibrary.org/iiif/b16736400/canvas/c0",
+          "@type": "sc:Canvas",
+          "label": " - ",
+          "thumbnail": {
+            "@id": "https://dlcs.io/thumbs/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://dlcs.io/thumbs/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249",
+              "protocol": "http://iiif.io/api/image",
+              "height": 1024,
+              "width": 729,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ],
+              "profile": [
+                "http://iiif.io/api/image/2/level0.json"
+              ]
+            }
+          },
+          "height": 6496,
+          "width": 4625,
+          "images": [
+            {
+              "@id": "https://wellcomelibrary.org/iiif/b16736400/imageanno/8fb54b80-80e6-427d-acd8-6a323f354249",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/!1024,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249",
+                  "profile": "http://iiif.io/api/image/2/level1.json"
+                }
+              },
+              "on": "https://wellcomelibrary.org/iiif/b16736400/canvas/c0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/model/WellcomeTest.php
+++ b/tests/model/WellcomeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace IIIF\Tests\model;
+
+
+use IIIF\Model\Collection;
+use IIIF\Model\LazyManifest;
+use IIIF\Model\Manifest;
+use PHPUnit\Framework\TestCase;
+
+class WellcomeTest extends TestCase
+{
+
+    public function test_it_can_parse_wellcome_collection()
+    {
+        $json = file_get_contents(__DIR__ . '/../fixtures/wellcome-collection.json');
+        $collection = Collection::fromJson($json);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals(54, sizeof($collection->getManifests()));
+        $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
+
+        $this->assertEquals(' Genre: Caricatures', $collection->getLabel());
+    }
+
+    public function test_it_can_load_wellcome_manifest()
+    {
+        $json = file_get_contents(__DIR__ . '/../fixtures/wellcome-manifest.json');
+        $manifest = Manifest::fromJson($json);
+        $this->assertNotEmpty($manifest->getLabel());
+        $this->assertEquals(1, sizeof($manifest->getThumbnails()));
+        $this->assertEquals('https://dlcs.io/thumbs/wellcome/1/8fb54b80-80e6-427d-acd8-6a323f354249/full/71,100/0/default.jpg', $manifest->getThumbnails()[0]);
+    }
+
+    public function test_it_can_load_manifests_lazily()
+    {
+        $json = file_get_contents(__DIR__ . '/../fixtures/wellcome-collection.json');
+        $collection = Collection::fromJson($json);
+        $collection->setManifestLoader(function ($url) {
+            $file = __DIR__ . '/../fixtures/http/' . md5($url);
+            if (file_exists($file)) {
+                return json_decode(file_get_contents($file), true);
+            }
+            throw new \Exception('Please comment out lines below to record test cases.');
+//            $content = file_get_contents($url);
+//            file_put_contents($file, $content);
+//            return json_decode($content, true);
+        });
+        foreach ($collection->getManifests() as $manifest) {
+            $this->assertInstanceOf(Manifest::class, $manifest);
+            $this->assertNotEmpty($manifest->getLabel());
+        }
+    }
+
+}


### PR DESCRIPTION
We made inaccurate assumptions about Image services, so now they inherit height and width from their resource if not explicitly set.