### PR TITLE
Increases test coverage to 100%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 script:
   - composer install
-  - ./vendor/bin/phpunit
-  - php coverage.php clover.xml 30
+  - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - php coverage.php build/logs/clover.xml 100

--- a/tests/model/CanvasTest.php
+++ b/tests/model/CanvasTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace IIIF\Tests\model;
+
+use IIIF\Model\Canvas;
+use PHPUnit\Framework\TestCase;
+
+class CanvasTest extends TestCase
+{
+
+  protected static $canvas;
+
+  public static function setUpBeforeClass()
+  {
+    $id = 'http://example.org/images/book1-page1/full/80,100/0/default.jpg';
+    $label = 'Book 1';
+    $thumbnail = 'http://example.org/images/book1-page1/full/80,100/0/default.jpg';
+    $height = 8;
+    $width = 16;
+    $images = [];
+    self::$canvas = new Canvas($id, $label, $thumbnail, $height, $width, $images);
+  }
+
+  public static function tearDownAfterClass()
+  {
+    self::$canvas = null;
+  }
+
+  public function testGetLabel()
+  {
+    $this->assertEquals(self::$canvas->getLabel(), 'Book 1');
+  }
+
+  public function testGetHeight()
+  {
+    $this->assertEquals(self::$canvas->getHeight(), 8);
+  }
+
+  public function testGetWidth()
+  {
+    $this->assertEquals(self::$canvas->getWidth(), 16);
+  }
+
+  public function testParseThumbnailService()
+  {
+    $data = array('@id' => 'http://example.org/images/book1-page1/full/80,100/0/default.jpg');
+    $this->assertEquals(Canvas::parseThumbnailService($data), 'http://example.org/images/book1-page1/full/80,100/0/default.jpg');
+  }
+
+  public function testParseThumbnailServiceWithInvalid()
+  {
+    $this->assertNull(Canvas::parseThumbnailService(true));
+  }
+
+  public function testParseThumbnailServiceWithString()
+  {
+    $this->assertEquals(Canvas::parseThumbnailService('http://example.org/images/book1-page1/full/80,100/0/default.jpg'), 'http://example.org/images/book1-page1/full/80,100/0/default.jpg');
+  }
+
+  public function testParseThumbnailServiceWithNull()
+  {
+    $this->assertNull(Canvas::parseThumbnailService(null));
+  }
+}

--- a/tests/model/CollectionTest.php
+++ b/tests/model/CollectionTest.php
@@ -9,56 +9,188 @@ use PHPUnit\Framework\TestCase;
 
 class CollectionTest extends TestCase
 {
-    public function test_can_load_collection_with_manifest_field()
-    {
-        $collectionData = file_get_contents(__DIR__.'/../fixtures/collection-manifest-field.json');
-        $collection = Collection::fromJson($collectionData);
-        $this->assertInstanceOf(Collection::class, $collection);
-        $this->assertEquals(5, sizeof($collection->getManifests()));
-        $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
 
-        $this->assertEquals('[Trawsfynydd Carnival, Images of O\'Brien and John Douglas]', $collection->getLabel());
-    }
+  protected static $collection;
 
-    public function test_can_load_collection_with_member_field()
-    {
-        $collectionData = file_get_contents(__DIR__.'/../fixtures/collection-member-field.json');
-        $collection = Collection::fromJson($collectionData);
-        $this->assertInstanceOf(Collection::class, $collection);
-        $this->assertEquals(12, sizeof($collection->getManifests()));
-        $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
+  protected function setUp()
+  {
 
-        $this->assertEquals('', $collection->getLabel());
-    }
+    $id = 'http://example.org/iiif/collection/top';
+    $manifests = [];
+    $label = 'Top Level Collection for Example Organization';
+    $description = 'Description of Collection';
+    $attribution = 'Provided by Example Organization';
+    $metadata = null;
 
-    public function test_is_collection()
-    {
-        $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
-        $this->assertTrue(Collection::isCollection($collection1));
+    self::$collection = new Collection(
+      $id,
+      $label,
+      $description,
+      $attribution,
+      $manifests,
+      $metadata
+    );
+  }
 
-        $collection2 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-manifest-field.json'), true);
-        $this->assertTrue(Collection::isCollection($collection2));
+  protected function tearDown()
+  {
+    self::$collection = null;
+  }
 
-        $manifest1 = json_decode(file_get_contents(__DIR__.'/../fixtures/manifest-a.json'), true);
-        $this->assertFalse(Collection::isCollection($manifest1));
+  public function test_can_load_collection_with_manifest_field()
+  {
+      $collectionData = file_get_contents(__DIR__.'/../fixtures/collection-manifest-field.json');
+      $collection = Collection::fromJson($collectionData);
+      $this->assertInstanceOf(Collection::class, $collection);
+      $this->assertEquals(5, sizeof($collection->getManifests()));
+      $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
 
-        $manifest2 = json_decode(file_get_contents(__DIR__.'/../fixtures/manifest-b.json'), true);
-        $this->assertFalse(Collection::isCollection($manifest2));
-    }
+      $this->assertEquals('[Trawsfynydd Carnival, Images of O\'Brien and John Douglas]', $collection->getLabel());
+  }
 
-    public function test_creation_using_factory()
-    {
-        $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
-        $collection = ResourceFactory::createCollection($collection1);
-        $this->assertInstanceOf(Collection::class, $collection);
+  public function test_can_load_collection_with_member_field()
+  {
+      $collectionData = file_get_contents(__DIR__.'/../fixtures/collection-member-field.json');
+      $collection = Collection::fromJson($collectionData);
+      $this->assertInstanceOf(Collection::class, $collection);
+      $this->assertEquals(12, sizeof($collection->getManifests()));
+      $this->assertContainsOnlyInstancesOf(LazyManifest::class, $collection->getManifests());
 
-        $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
-        $collection = ResourceFactory::create($collection1);
-        $this->assertInstanceOf(Collection::class, $collection);
+      $this->assertEquals('', $collection->getLabel());
+  }
 
-        $collection = ResourceFactory::create(__DIR__.'/../fixtures/collection-member-field.json', function ($file) {
-            return json_decode(file_get_contents($file), true);
-        });
-        $this->assertInstanceOf(Collection::class, $collection);
-    }
+  public function test_is_collection()
+  {
+      $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
+      $this->assertTrue(Collection::isCollection($collection1));
+
+      $collection2 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-manifest-field.json'), true);
+      $this->assertTrue(Collection::isCollection($collection2));
+
+      $manifest1 = json_decode(file_get_contents(__DIR__.'/../fixtures/manifest-a.json'), true);
+      $this->assertFalse(Collection::isCollection($manifest1));
+
+      $manifest2 = json_decode(file_get_contents(__DIR__.'/../fixtures/manifest-b.json'), true);
+      $this->assertFalse(Collection::isCollection($manifest2));
+  }
+
+  public function test_creation_using_factory()
+  {
+      $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
+      $collection = ResourceFactory::createCollection($collection1);
+      $this->assertInstanceOf(Collection::class, $collection);
+
+      $collection1 = json_decode(file_get_contents(__DIR__.'/../fixtures/collection-member-field.json'), true);
+      $collection = ResourceFactory::create($collection1);
+      $this->assertInstanceOf(Collection::class, $collection);
+
+      $collection = ResourceFactory::create(__DIR__.'/../fixtures/collection-member-field.json', function ($file) {
+          return json_decode(file_get_contents($file), true);
+      });
+      $this->assertInstanceOf(Collection::class, $collection);
+  }
+
+  public function testGetManifestsFromData()
+  {
+    $manifest1 = array(
+      '@id' => 'http://example.org/iiif/book1/manifest',
+      'label' => 'Book 1',
+      'sequences' => []
+    );
+    $manifest2 = array(
+      '@id' => 'http://example.org/iiif/book2/manifest',
+      'label' => 'Book 2',
+      'sequences' => []
+    );
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => 'Top Level Collection for Example Organization',
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization',
+      'manifests' => [$manifest1, $manifest2]
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertCount(2, $collection->getManifests());
+  }
+
+  public function testGetManifestsFromDataWithMembers()
+  {
+    $manifest1 = array(
+      '@id' => 'http://example.org/iiif/book1/manifest',
+      'label' => 'Book 1',
+      'sequences' => []
+    );
+    $manifest2 = array(
+      '@id' => 'http://example.org/iiif/book2/manifest',
+      'label' => 'Book 2',
+      'sequences' => []
+    );
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => 'Top Level Collection for Example Organization',
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization',
+      'members' => [$manifest1, $manifest2]
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertCount(2, $collection->getManifests());
+  }
+
+  public function testGetManifestsFromDataWhenEmpty()
+  {
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => 'Top Level Collection for Example Organization',
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization'
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertEmpty($collection->getManifests());
+  }
+
+  public function testGetLabelFromData()
+  {
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => 'Top Level Collection for Example Organization',
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization',
+      'manifests' => []
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertEquals('Top Level Collection for Example Organization', $collection->getLabel());
+  }
+
+  public function testGetLabelFromDataWithArray()
+  {
+    $label = array('@value' => 'Top Level Collection for Example Organization');
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => $label,
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization',
+      'manifests' => []
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertEquals('Top Level Collection for Example Organization', $collection->getLabel());
+  }
+
+  public function testGetLabelFromDataWithNestedArray()
+  {
+    $label = array(array('@value' => 'Top Level Collection for Example Organization'));
+    $data = array(
+      '@id' => 'http://example.org/iiif/collection/top',
+      'label' => $label,
+      'description' => 'Description of Collection',
+      'attribution' => 'Provided by Example Organization',
+      'manifests' => []
+    );
+    $collection = Collection::fromArray($data);
+    $this->assertEquals('Top Level Collection for Example Organization', $collection->getLabel());
+  }
+
+  public function testGetId()
+  {
+    $this->assertEquals('http://example.org/iiif/collection/top', self::$collection->getId());
+  }
 }

--- a/tests/model/ImageServiceTest.php
+++ b/tests/model/ImageServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace IIIF\Tests\model;
+
+use IIIF\Model\ImageService;
+use IIIF\Model\Tile;
+use PHPUnit\Framework\TestCase;
+
+class ImageServiceTest extends TestCase
+{
+  protected static $imageService;
+
+  protected function setUp()
+  {
+    $id = 'http://example.org/images/book1-page2';
+    $height = 8000;
+    $width = 6000;
+    $tile1 = new Tile(512, 256, array(1,2,4,8,16));
+    $tile2 = new Tile(128, 64, array(1,2,4,8,16));
+    $tiles = array($tile1, $tile2);
+
+    self::$imageService = new ImageService($id, $height, $width, $tiles);
+  }
+
+  protected function tearDown()
+  {
+    self::$imageService = null;
+  }
+
+  public function testGetTile()
+  {
+    $tile1 = self::$imageService->getTile(0);
+    $this->assertInstanceOf('IIIF\Model\Tile', $tile1);
+    $this->assertEquals(512, $tile1->getLargestDimension());
+
+    $tile2 = self::$imageService->getTile(1);
+    $this->assertInstanceOf('IIIF\Model\Tile', $tile2);
+    $this->assertEquals(128, $tile2->getLargestDimension());
+  }
+}

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace IIIF\Tests\model;
+
+use IIIF\Model\Image;
+use IIIF\Model\ImageResource;
+use IIIF\Model\ImageService;
+use PHPUnit\Framework\TestCase;
+
+class ImageTest extends TestCase
+{
+  protected static $image;
+
+  protected function setUp()
+  {
+    $id = 'http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C';
+    $motivation = 'sc:painting';
+    $on = 'http://example.org/iiif/book1/canvas/p1';
+    $imageService = new ImageResource('', null, null, 0, 0, null);
+
+    self::$image = new Image($id, $motivation, $on, $imageService);
+  }
+
+  protected function tearDown()
+  {
+    self::$image = null;
+  }
+
+  public function testGetId()
+  {
+    $this->assertEquals('http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C', self::$image->getId());
+  }
+
+  public function testGetIdWithService()
+  {
+    $id = 'http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C';
+    $imageService = new ImageService($id, 8, 16, array());
+    $imageResource = new ImageResource(
+      'http://example.org/iiif/book1/res/page1.jpg',
+      'dctypes:Image',
+      'image/jpeg',
+      2000,
+      1500,
+      $imageService
+    );
+    $motivation = 'sc:painting';
+    $on = 'http://example.org/iiif/book1/canvas/p1';
+
+    $image = new Image('', $motivation, $on, $imageResource);
+
+    $this->assertEquals($id, $image->getId());
+  }
+
+  public function testGetMotivation()
+  {
+    $this->assertEquals('sc:painting', self::$image->getMotivation());
+  }
+
+  public function testGetOn()
+  {
+    $this->assertEquals('http://example.org/iiif/book1/canvas/p1', self::$image->getOn());
+  }
+}

--- a/tests/model/LazyManifestTest.php
+++ b/tests/model/LazyManifestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace IIIF\Tests\model;
+
+use IIIF\Model\LazyManifest;
+use PHPUnit\Framework\TestCase;
+
+class LazyManifestTest extends TestCase
+{
+
+  protected static $lazyManifest;
+
+  protected function setUp()
+  {
+    $id = __DIR__ . '/../fixtures/manifest-a.json';
+    $label = 'Book 1';
+    $sequences = [];
+
+    self::$lazyManifest = new LazyManifest($id, $label, $sequences);
+  }
+
+  protected function tearDown()
+  {
+    self::$lazyManifest = null;
+  }
+
+  public function testLoad()
+  {
+    // self::$lazyManifest->load() is invoked here only once within self::$lazyManifest->getSequence(0)
+    $sequence = self::$lazyManifest->getSequence(0);
+    $this->assertInstanceOf('IIIF\Model\Sequence', $sequence);
+  }
+
+  public function testLoadWhenLoaded()
+  {
+    self::$lazyManifest->load();
+    $this->assertNull(self::$lazyManifest->load());
+  }
+
+  public function testGetDefaultSequence()
+  {
+    $sequence = self::$lazyManifest->getDefaultSequence();
+    $this->assertInstanceOf('IIIF\Model\Sequence', $sequence);
+  }
+}

--- a/tests/model/ManifestTest.php
+++ b/tests/model/ManifestTest.php
@@ -164,4 +164,38 @@ class ManifestTest extends TestCase
         });
         $this->assertInstanceOf(Manifest::class, $manifest);
     }
+
+    public function testGetCanvasRegionFromUrl()
+    {
+      $id = __DIR__ . '/../fixtures/manifest-a.json';
+      $manifest = ResourceFactory::create($id, function ($file) {
+        return json_decode(file_get_contents($file), true);
+      });
+      $uri = 'http://dams.llgc.org.uk/iiif/2.0/4654878/canvas/4654879.json#xywh=0,0,600,900';
+      $regionUrl = $manifest->getCanvasRegionFromUrl($uri);
+      $this->assertEquals('http://dams.llgc.org.uk/iiif/2.0/image/4654879/0,0,600,900/256,/0/default.jpg', $regionUrl);
+    }
+
+    public function testGetCanvasRegionFromUrlWhenNull()
+    {
+      $id = __DIR__ . '/../fixtures/manifest-a.json';
+      $manifest = ResourceFactory::create($id, function ($file) {
+        return json_decode(file_get_contents($file), true);
+      });
+      $uri = 'http://dams.llgc.org.uk/iiif/2.0/4654878/canvas/invalid.json#xywh=0,0,600,900';
+      $regionUrl = $manifest->getCanvasRegionFromUrl($uri);
+      $this->assertNull($regionUrl);
+    }
+
+    public function testGetCanvasNumber()
+    {
+      $id = __DIR__ . '/../fixtures/manifest-a.json';
+      $manifest = ResourceFactory::create($id, function ($file) {
+        return json_decode(file_get_contents($file), true);
+      });
+
+      $canvas = $manifest->getCanvasNumber(0);
+      $this->assertInstanceOf('IIIF\Model\Canvas', $canvas);
+      $this->assertEquals('http://dams.llgc.org.uk/iiif/2.0/4654878/canvas/4654879.json', $canvas->getId());
+    }
 }

--- a/tests/model/ResourceFactoryTest.php
+++ b/tests/model/ResourceFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace IIIF\Tests\model;
+
+use LogicException;
+use IIIF\ResourceFactory;
+use PHPUnit\Framework\TestCase;
+
+class ResourceFactoryTest extends TestCase
+{
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage You must pass in a data loader
+     */
+    public function testCreateWithoutLoader()
+    {
+      $file = __DIR__ . '/../fixtures/manifest-a.json';
+      $data = file_get_contents($file);
+      ResourceFactory::create($data, null);
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Invalid data provided.
+     */
+    public function testCreateWithInvalidData()
+    {
+      $data = array('@type' => 'foo');
+      ResourceFactory::create($data, null);
+    }
+}

--- a/tests/model/WellcomeTest.php
+++ b/tests/model/WellcomeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace IIIF\Tests\model;
-
 
 use IIIF\Model\Collection;
 use IIIF\Model\LazyManifest;
@@ -42,9 +40,6 @@ class WellcomeTest extends TestCase
                 return json_decode(file_get_contents($file), true);
             }
             throw new \Exception('Please comment out lines below to record test cases.');
-//            $content = file_get_contents($url);
-//            file_put_contents($file, $content);
-//            return json_decode($content, true);
         });
         foreach ($collection->getManifests() as $manifest) {
             $this->assertInstanceOf(Manifest::class, $manifest);

--- a/tests/model/WithMetaDataTest.php
+++ b/tests/model/WithMetaDataTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace IIIF\tests\model;
+
+use IIIF\Model\WithMetaData;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class defined for the purposes of testing the Trait
+ */
+class MyResource {
+  use WithMetaData;
+
+  private $id;
+
+  public function __construct($id, $metaData)
+  {
+    $this->id = $id;
+    $this->metaData = $metaData;
+  }
+}
+
+class WithMetaDataTest extends TestCase
+{
+  protected static $myResource;
+
+  protected function setUp()
+  {
+    $id = 'http://example.org/iiif/my-resource';
+    $metaData = array('testLabel1' => 'test value 1');
+
+    self::$myResource = new MyResource($id, $metaData);
+  }
+
+  protected function tearDown()
+  {
+    self::$myResource = null;
+  }
+
+  public function testWithMetaData()
+  {
+    $data = array('testLabel2' => 'test value 2');
+    $updated = self::$myResource->withMetaData($data);
+    $this->assertInstanceOf('IIIF\tests\model\MyResource', $updated);
+    $this->assertEquals('test value 2', $updated->testLabel2);
+    $this->assertEquals('test value 1', $updated->testLabel1);
+  }
+
+  public function testWithMetaDataWithoutMerge()
+  {
+    $data = array('testLabel2' => 'test value 2');
+    $updated = self::$myResource->withMetaData($data, false);
+    $this->assertInstanceOf('IIIF\tests\model\MyResource', $updated);
+    $this->assertEquals('test value 2', $updated->testLabel2);
+    $this->assertNull($updated->testLabel1);
+  }
+}


### PR DESCRIPTION
- Removes comments from the `WellcomeTest`
- Improves test coverage for:
  - `Canvas`
  - `ResourceFactory`
  - `LazyManifest`
  - `Collection`
  - `WithMetaData`
  - `Manifest`
- Ensures that Travis CI builds for 7.2.x releases and checks for 100% test coverage